### PR TITLE
Setup separate builds for nitro-client in browser and Node.js environments

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,8 +24,8 @@ jobs:
         run: yarn
       - name: "Linter check"
         run: yarn lint
-  test:
-    name: "Run tests"
+  test-browser:
+    name: "Run tests for browser"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,5 +40,23 @@ jobs:
         run: yarn
       - name: "Run tests"
         run: |
-          yarn build --ignore @cerc-io/example-web-app
-          yarn test
+          yarn build:browser --ignore @cerc-io/example-web-app
+          yarn test:browser
+  test-node:
+    name: "Run tests for node"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Use Node.js ${{ matrix.node-version }}"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: "Install dependencies"
+        run: yarn
+      - name: "Run tests"
+        run: |
+          yarn build:node
+          yarn test:node

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "lint": "lerna run lint --stream",
-    "build:browser": "lerna run build,build:browser --stream",
-    "build:node": "lerna run build,build:node --stream --ignore @cerc-io/example-web-app",
+    "build:browser": "lerna run build:browser,build --stream",
+    "build:node": "lerna run build:node,build --stream --ignore @cerc-io/example-web-app",
     "test:browser": "lerna run test --stream",
     "test:node": "lerna run test --stream --ignore @cerc-io/example-web-app"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "lint": "lerna run lint --stream",
-    "build": "lerna run build --stream",
+    "build:browser": "lerna run build,build:browser --stream",
+    "build:node": "lerna run build,build:node --stream --ignore @cerc-io/example-web-app",
     "test": "lerna run test --stream"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "lerna run lint --stream",
     "build:browser": "lerna run build,build:browser --stream",
     "build:node": "lerna run build,build:node --stream --ignore @cerc-io/example-web-app",
-    "test": "lerna run test --stream"
+    "test:browser": "lerna run test --stream",
+    "test:node": "lerna run test --stream --ignore @cerc-io/example-web-app"
   }
 }

--- a/packages/example-web-app/package.json
+++ b/packages/example-web-app/package.json
@@ -40,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint-config-react-app": "^7.0.1"
   }
 }

--- a/packages/example-web-app/package.json
+++ b/packages/example-web-app/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.31",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
+    "ethers": "^5.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/packages/nitro-client/.gitignore
+++ b/packages/nitro-client/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 
 dist
+
+# Generated using script before build
+src/index.ts

--- a/packages/nitro-client/package.json
+++ b/packages/nitro-client/package.json
@@ -35,7 +35,10 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
+    "@chainsafe/libp2p-yamux": "^4.0.2",
+    "@libp2p/crypto": "^1.0.4",
     "@libp2p/mdns": "^8.0.0",
+    "@libp2p/tcp": "^7.0.1",
     "@nodeguy/channel": "^1.0.2",
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",

--- a/packages/nitro-client/package.json
+++ b/packages/nitro-client/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cerc-io/nitro-client",
   "version": "0.1.0",
-  "main": "dist/index.js",
+  "main": "dist/node.js",
+  "browser": "dist/browser.js",
   "license": "MIT",
   "scripts": {
     "build": "webpack --config webpack.prod.ts",
@@ -12,6 +13,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",
+    "@types/debug": "^4.1.7",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.2.1",
     "@types/webpack": "^5.28.1",
@@ -40,7 +42,6 @@
     "@libp2p/mdns": "^8.0.0",
     "@libp2p/tcp": "^7.0.1",
     "@nodeguy/channel": "^1.0.2",
-    "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "ethers": "^6.4.0",
     "libp2p": "^0.45.3"

--- a/packages/nitro-client/package.json
+++ b/packages/nitro-client/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@cerc-io/nitro-client",
   "version": "0.1.0",
-  "main": "dist/node.js",
-  "browser": "dist/browser.js",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --config webpack.prod.ts",
-    "build:dev": "webpack --config webpack.dev.ts",
+    "index:browser": "cp src/browser.ts src/index.ts",
+    "index:node": "cp src/node.ts src/index.ts",
+    "build:browser": "yarn index:browser && webpack --config webpack.prod.ts --env target=browser",
+    "build:node": "yarn index:node && webpack --config webpack.prod.ts --env target=node",
+    "build:dev:browser": "yarn index:browser && webpack --config webpack.dev.ts --env target=browser",
+    "build:dev:node": "yarn index:node && webpack --config webpack.dev.ts --env target=node",
     "dev": "webpack --watch --config webpack.dev.ts",
     "lint": "eslint .",
     "test": "mocha"

--- a/packages/nitro-client/package.json
+++ b/packages/nitro-client/package.json
@@ -46,7 +46,7 @@
     "@libp2p/tcp": "^7.0.1",
     "@nodeguy/channel": "^1.0.2",
     "debug": "^4.3.4",
-    "ethers": "^6.4.0",
+    "ethers": "^5.7.2",
     "libp2p": "^0.45.3"
   }
 }

--- a/packages/nitro-client/src/browser.ts
+++ b/packages/nitro-client/src/browser.ts
@@ -1,0 +1,6 @@
+export const test = (): string => {
+  // eslint-disable-next-line no-console
+  console.log('Test from nitro-client');
+
+  return 'test output';
+};

--- a/packages/nitro-client/src/browser.ts
+++ b/packages/nitro-client/src/browser.ts
@@ -1,3 +1,6 @@
+export { Client } from './client/client';
+export { EthChainService } from './client/engine/chainservice/eth-chainservice';
+
 export const test = (): string => {
   // eslint-disable-next-line no-console
   console.log('Test from nitro-client');

--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -115,7 +115,7 @@ export class State {
   // TODO: Can throw an error
   // TODO: Implement
   recoverSigner(sig: Signature): Address {
-    return ethers.ZeroAddress;
+    return ethers.constants.AddressZero;
   }
 
   // Equal returns true if the given State is deeply equal to the receiever.

--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -14,7 +14,7 @@ export class Client {
   private vm: VoucherManager;
 
   constructor(msg: MessageService, chain: ChainService, store: Store, policymaker: PolicyMaker) {
-    this.vm = new VoucherManager(ethers.ZeroAddress, store);
+    this.vm = new VoucherManager(ethers.constants.AddressZero, store);
     this.engine = new Engine(this.vm, msg, chain, store, policymaker);
   }
 }

--- a/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
@@ -1,7 +1,7 @@
-import { AddressLike } from 'ethers';
 import type { ReadChannel } from '@nodeguy/channel';
 
 import { ChainTransaction } from '../../../protocols/interfaces';
+import { Address } from '../../../types/types';
 
 // ChainEvent dictates which methods all chain events must implement
 export interface ChainEvent {
@@ -17,9 +17,9 @@ export interface ChainService {
   sendTransaction (tx: ChainTransaction): void;
 
   // TODO: Use Address type
-  getConsensusAppAddress (): AddressLike;
+  getConsensusAppAddress (): Address;
 
-  getVirtualPaymentAppAddress (): AddressLike;
+  getVirtualPaymentAppAddress (): Address;
 
   // TODO: Can throw an error
   getChainId (): bigint;

--- a/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
@@ -1,12 +1,12 @@
-import {
-  AddressLike, Log, TransactionLike, ethers,
-} from 'ethers';
+import { ethers } from 'ethers';
 import debug from 'debug';
 import type { ReadChannel, ReadWriteChannel } from '@nodeguy/channel';
 
+import { Log } from '@ethersproject/abstract-provider'
 import { NitroAdjudicator } from './adjudicator/nitro-adjudicator';
 import { ChainService, ChainEvent } from './chainservice';
 import { ChainTransaction } from '../../../protocols/interfaces';
+import { Address } from '../../../types/types';
 
 interface EthChain {
   // TODO: Extend bind.ContractBackend (github.com/ethereum/go-ethereum/accounts/abi/bind)
@@ -26,13 +26,13 @@ export class EthChainService implements ChainService {
 
   private na: NitroAdjudicator;
 
-  private naAddress: AddressLike;
+  private naAddress: string;
 
-  private consensusAppAddress: AddressLike;
+  private consensusAppAddress: string;
 
-  private virtualPaymentAppAddress: AddressLike;
+  private virtualPaymentAppAddress: string;
 
-  private txSigner: TransactionLike;
+  private txSigner: ethers.Transaction;
 
   private out: ReadWriteChannel<ChainEvent>;
 
@@ -45,10 +45,10 @@ export class EthChainService implements ChainService {
   constructor(
     chain: EthChain,
     na: NitroAdjudicator,
-    naAddress: AddressLike,
-    consensusAppAddress: AddressLike,
-    virtualPaymentAppAddress: AddressLike,
-    txSigner: TransactionLike,
+    naAddress: string,
+    consensusAppAddress: string,
+    virtualPaymentAppAddress: string,
+    txSigner: ethers.Transaction,
     out: ReadWriteChannel<ChainEvent>,
     logger: debug.Debugger,
     ctx: AbortController,
@@ -71,15 +71,15 @@ export class EthChainService implements ChainService {
   static newEthChainService(
     chainUrl: string,
     chainPk: string,
-    naAddress: AddressLike,
-    caAddress: AddressLike,
-    vpaAddress: AddressLike,
+    naAddress: string,
+    caAddress: string,
+    vpaAddress: string,
     logDestination: WritableStream,
   ): EthChainService | void {}
 
   // defaultTxOpts returns transaction options suitable for most transaction submissions
   // TODO: Implement and remove void
-  private defaultTxOpts(): TransactionLike | void {}
+  private defaultTxOpts(): ethers.Transaction | void {}
 
   // sendTransaction sends the transaction and blocks until it has been submitted.
   // TODO: Implement and remove void
@@ -109,13 +109,13 @@ export class EthChainService implements ChainService {
   }
 
   // TODO: Implement
-  getConsensusAppAddress(): AddressLike {
-    return ethers.ZeroAddress;
+  getConsensusAppAddress(): Address {
+    return ethers.constants.AddressZero;
   }
 
   // TODO: Implement
-  getVirtualPaymentAppAddress(): AddressLike {
-    return ethers.ZeroAddress;
+  getVirtualPaymentAppAddress(): Address {
+    return ethers.constants.AddressZero;
   }
 
   // TODO: Implement and remove void

--- a/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
@@ -1,8 +1,8 @@
 import { ethers } from 'ethers';
 import debug from 'debug';
-import type { ReadChannel, ReadWriteChannel } from '@nodeguy/channel';
 
-import { Log } from '@ethersproject/abstract-provider'
+import type { ReadChannel, ReadWriteChannel } from '@nodeguy/channel';
+import type { Log } from '@ethersproject/abstract-provider';
 import { NitroAdjudicator } from './adjudicator/nitro-adjudicator';
 import { ChainService, ChainEvent } from './chainservice';
 import { ChainTransaction } from '../../../protocols/interfaces';

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -194,7 +194,6 @@ export class Engine {
 
   // GetConsensusAppAddress returns the address of a deployed ConsensusApp (for ledger channels)
   getConsensusAppAddress(): Address {
-    ethers.utils.getAddress
     return ethers.constants.AddressZero;
   }
 

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -1,4 +1,4 @@
-import { AddressLike, ethers } from 'ethers';
+import { ethers } from 'ethers';
 import createChannel from '@nodeguy/channel';
 import type { ReadChannel, ReadWriteChannel } from '@nodeguy/channel';
 
@@ -12,6 +12,7 @@ import { Objective, ObjectiveRequest, SideEffects } from '../../protocols/interf
 import { Message, ObjectiveId, ObjectivePayload } from '../../protocols/messages';
 import { Objective as VirtualFundObjective } from '../../protocols/virtualfund/virtualfund';
 import { Proposal } from '../../channel/consensus-channel/consensus-channel';
+import { Address } from '../../types/types';
 
 export type PaymentRequest = {
   channelId: string
@@ -192,13 +193,14 @@ export class Engine {
   }
 
   // GetConsensusAppAddress returns the address of a deployed ConsensusApp (for ledger channels)
-  getConsensusAppAddress(): AddressLike {
-    return ethers.ZeroAddress;
+  getConsensusAppAddress(): Address {
+    ethers.utils.getAddress
+    return ethers.constants.AddressZero;
   }
 
   // GetVirtualPaymentAppAddress returns the address of a deployed VirtualPaymentApp
-  getVirtualPaymentAppAddress(): AddressLike {
-    return ethers.ZeroAddress;
+  getVirtualPaymentAppAddress(): Address {
+    return ethers.constants.AddressZero;
   }
 
   // logMessage logs a message to the engine's logger

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
@@ -25,8 +25,8 @@ import { Address } from '../../../../types/types';
 
 const log = debug('ts-nitro:p2p-message-service');
 
-const PROTOCOL_ID = '/ts-nitro/msg/1.0.0';
-const PEER_EXCHANGE_PROTOCOL_ID = '/ts-nitro/peerinfo/1.0.0';
+const PROTOCOL_ID = '/go-nitro/msg/1.0.0';
+const PEER_EXCHANGE_PROTOCOL_ID = '/go-nitro/peerinfo/1.0.0';
 const BUFFER_SIZE = 1_000;
 
 // BasicPeerInfo contains the basic information about a peer

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -1,4 +1,4 @@
-import { AddressLike, ethers } from 'ethers';
+import { ethers } from 'ethers';
 
 import { Store } from './store';
 import { Objective } from '../../../protocols/interfaces';
@@ -7,6 +7,7 @@ import { ConsensusChannel } from '../../../channel/consensus-channel/consensus-c
 import { VoucherInfo } from '../../../payments/vouchers';
 import { SyncMap } from '../../../internal/safesync/safesync';
 import { ObjectiveId } from '../../../protocols/messages';
+import { Address } from '../../../types/types';
 
 export class MemStore implements Store {
   obectives: SyncMap<Buffer>;
@@ -41,8 +42,8 @@ export class MemStore implements Store {
   close(): void {}
 
   // TODO: Implement
-  getAddress(): AddressLike {
-    return ethers.ZeroAddress;
+  getAddress(): Address {
+    return ethers.constants.AddressZero;
   }
 
   // TODO: Implement
@@ -86,12 +87,12 @@ export class MemStore implements Store {
   }
 
   // TODO: Implement
-  getChannelsByAppDefinition(appDef: AddressLike): Channel[] {
+  getChannelsByAppDefinition(appDef: Address): Channel[] {
     return [];
   }
 
   // TODO: Implement
-  getChannelsByParticipant(participant: AddressLike): Channel[] {
+  getChannelsByParticipant(participant: Address): Channel[] {
     return [];
   }
 
@@ -101,7 +102,7 @@ export class MemStore implements Store {
   }
 
   // TODO: Implement
-  getConsensusChannel(counterparty: AddressLike): ConsensusChannel {
+  getConsensusChannel(counterparty: Address): ConsensusChannel {
     return {};
   }
 

--- a/packages/nitro-client/src/client/engine/store/store.ts
+++ b/packages/nitro-client/src/client/engine/store/store.ts
@@ -1,9 +1,8 @@
-import { AddressLike } from 'ethers';
-
 import { Objective } from '../../../protocols/interfaces';
 import { Channel } from '../../../channel/channel';
 import { ConsensusChannel } from '../../../channel/consensus-channel/consensus-channel';
 import { VoucherStore } from '../../../payments/voucher-manager';
+import { Address } from '../../../types/types';
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 export interface Store extends ConsensusChannelStore, VoucherStore {
@@ -11,7 +10,7 @@ export interface Store extends ConsensusChannelStore, VoucherStore {
   getChannelSecretKey (): string
 
   // Get the (Ethereum) address associated with the ChannelSecretKey
-  getAddress (): AddressLike
+  getAddress (): Address
 
   // Read an existing objective
   // TODO: Can throw an error
@@ -33,7 +32,7 @@ export interface Store extends ConsensusChannelStore, VoucherStore {
   getChannelById (id: string): Channel
 
   // Returns any channels that includes the given participant
-  getChannelsByParticipant (participant: AddressLike): Channel[]
+  getChannelsByParticipant (participant: Address): Channel[]
 
   // TODO: Can throw an error
   setChannel (ch: Channel): void
@@ -42,7 +41,7 @@ export interface Store extends ConsensusChannelStore, VoucherStore {
 
   // Returns any channels that includes the given app definition
   // TODO: Can throw an error
-  getChannelsByAppDefinition (appDef: AddressLike): Channel[]
+  getChannelsByAppDefinition (appDef: Address): Channel[]
 
   // Release channel from being owned by any objective
   releaseChannelFromOwnership (channelId: string): void
@@ -58,7 +57,7 @@ export interface ConsensusChannelStore {
   getAllConsensusChannels (): ConsensusChannel[]
 
   // TODO: Can throw an error
-  getConsensusChannel (counterparty: AddressLike): ConsensusChannel
+  getConsensusChannel (counterparty: Address): ConsensusChannel
 
   // TODO: Can throw an error
   getConsensusChannelById (id: string): ConsensusChannel

--- a/packages/nitro-client/src/index.ts
+++ b/packages/nitro-client/src/index.ts
@@ -4,7 +4,3 @@ export const test = (): string => {
 
   return 'test output';
 };
-
-export { Client } from './client/client';
-export { EthChainService } from './client/engine/chainservice/eth-chainservice';
-export { P2PMessageService } from './client/engine/messageservice/p2p-message-service/service';

--- a/packages/nitro-client/src/index.ts
+++ b/packages/nitro-client/src/index.ts
@@ -1,3 +1,6 @@
+export { Client } from './client/client';
+export { EthChainService } from './client/engine/chainservice/eth-chainservice';
+
 export const test = (): string => {
   // eslint-disable-next-line no-console
   console.log('Test from nitro-client');

--- a/packages/nitro-client/src/index.ts
+++ b/packages/nitro-client/src/index.ts
@@ -1,9 +1,0 @@
-export { Client } from './client/client';
-export { EthChainService } from './client/engine/chainservice/eth-chainservice';
-
-export const test = (): string => {
-  // eslint-disable-next-line no-console
-  console.log('Test from nitro-client');
-
-  return 'test output';
-};

--- a/packages/nitro-client/src/node.ts
+++ b/packages/nitro-client/src/node.ts
@@ -1,0 +1,3 @@
+export { Client } from './client/client';
+export { EthChainService } from './client/engine/chainservice/eth-chainservice';
+export { P2PMessageService } from './client/engine/messageservice/p2p-message-service/service';

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -1,5 +1,3 @@
-import { AddressLike } from 'ethers';
-
 import { Voucher, VoucherInfo } from './vouchers';
 
 // VoucherStore is an interface for storing voucher information that the voucher manager expects.
@@ -21,16 +19,16 @@ export interface VoucherStore {
 export class VoucherManager {
   private store: VoucherStore;
 
-  private me: AddressLike;
+  private me: string;
 
-  constructor(me: AddressLike, store: VoucherStore) {
+  constructor(me: string, store: VoucherStore) {
     this.store = store;
     this.me = me;
   }
 
   // Register registers a channel for use, given the payer, payee and starting balance of the channel
   // TODO: Can throw an error
-  register(channelId: string, payer: AddressLike, payee: AddressLike, startingBalance: bigint): void {}
+  register(channelId: string, payer: string, payee: string, startingBalance: bigint): void {}
 
   // Remove deletes the channel's status
   // TODO: Can throw an error

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -1,5 +1,3 @@
-import { AddressLike } from 'ethers';
-
 // A Voucher signed by Alice can be used by Bob to redeem payments in case of
 // a misbehaving Alice.
 //
@@ -16,9 +14,9 @@ export class Voucher {}
 // As well as details about the balance and who the payee/payer is.
 // TODO: Implement
 export class VoucherInfo {
-  channelPayer?: AddressLike;
+  channelPayer?: string;
 
-  channelPayee?: AddressLike;
+  channelPayee?: string;
 
   startingBalance?: bigint;
 

--- a/packages/nitro-client/src/protocols/interfaces.ts
+++ b/packages/nitro-client/src/protocols/interfaces.ts
@@ -1,7 +1,6 @@
-import { AddressLike } from 'ethers';
-
 import { Message, ObjectiveId, ObjectivePayload } from './messages';
 import { Proposal } from '../channel/consensus-channel/consensus-channel';
+import { Address } from '../types/types';
 
 // ChainTransaction defines the interface that every transaction must implement
 export interface ChainTransaction {
@@ -74,7 +73,7 @@ export enum ObjectiveStatus {
 
 // ObjectiveRequest is a request to create a new objective.
 export interface ObjectiveRequest {
-  id (address: AddressLike, chainId: bigint): ObjectiveId
+  id (address: Address, chainId: bigint): ObjectiveId
   waitForObjectiveToStart (): void
   signalObjectiveStarted (): void
 }

--- a/packages/nitro-client/src/types/types.ts
+++ b/packages/nitro-client/src/types/types.ts
@@ -1,6 +1,4 @@
-import { AddressLike } from 'ethers';
-
-export type Address = AddressLike;
+export type Address = string;
 
 // TODO: Add Destination type
 // Destination represents a payable address in go-nitro. In a state channel network,

--- a/packages/nitro-client/test/browser.test.ts
+++ b/packages/nitro-client/test/browser.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { test } from '../src/index';
+import { test } from '../src/browser';
 
 describe('testFunction', () => {
   it('should return the expected result', () => {

--- a/packages/nitro-client/tsconfig.json
+++ b/packages/nitro-client/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ES5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2020",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["es6", "dom"],                               /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ES6",                                     /* Specify what module code is generated. */
+    "module": "ES2020",                                     /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/packages/nitro-client/webpack.common.ts
+++ b/packages/nitro-client/webpack.common.ts
@@ -1,15 +1,17 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
+import { merge } from 'webpack-merge';
 
-const config: webpack.Configuration = {
-  mode: 'production',
-  entry: './src/index.ts',
+const baseConfig: webpack.Configuration = {
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'index.js',
-    library: '@cerc-io/nitro-client',
+    library: {
+      name: '@cerc-io/nitro-client',
+      type: 'umd',
+    },
     libraryTarget: 'umd',
     globalObject: 'this',
+    clean: true
   },
   resolve: {
     extensions: ['.ts', '.js'],
@@ -19,17 +21,38 @@ const config: webpack.Configuration = {
       {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: /node_modules/,
+        exclude: /node_modules/
       },
     ],
   },
-  // TODO: Remove/refactor when building for browser
-  target: 'node',
-  // https://github.com/websockets/ws/issues/1126#issuecomment-631605589
   externals: {
-    bufferutil: 'bufferutil',
-    'utf-8-validate': 'utf-8-validate',
+    '@chainsafe/libp2p-yamux': '@chainsafe/libp2p-yamux',
+    '@libp2p/crypto': '@libp2p/crypto',
+    '@libp2p/mdns': '@libp2p/mdns',
+    '@libp2p/tcp': '@libp2p/tcp',
+    '@nodeguy/channel': '@nodeguy/channel',
+    debug: 'debug',
+    ethers: 'ethers',
+    libp2p: 'libp2p',
   },
 };
 
-export default config;
+export const browserConfig: webpack.Configuration = merge(baseConfig, {
+  entry: './src/browser.ts',
+  output: {
+    filename: 'browser.js',
+  },
+});
+
+export const nodeConfig: webpack.Configuration = merge(baseConfig, {
+  entry: './src/node.ts',
+  output: {
+    filename: 'node.js',
+  },
+  target: 'node'
+});
+
+export default [
+  browserConfig,
+  nodeConfig,
+];

--- a/packages/nitro-client/webpack.common.ts
+++ b/packages/nitro-client/webpack.common.ts
@@ -23,6 +23,13 @@ const config: webpack.Configuration = {
       },
     ],
   },
+  // TODO: Remove/refactor when building for browser
+  target: 'node',
+  // https://github.com/websockets/ws/issues/1126#issuecomment-631605589
+  externals: {
+    bufferutil: 'bufferutil',
+    'utf-8-validate': 'utf-8-validate',
+  },
 };
 
 export default config;

--- a/packages/nitro-client/webpack.common.ts
+++ b/packages/nitro-client/webpack.common.ts
@@ -11,7 +11,8 @@ const baseConfig: webpack.Configuration = {
     },
     libraryTarget: 'umd',
     globalObject: 'this',
-    clean: true
+    clean: true,
+    filename: 'index.js',
   },
   resolve: {
     extensions: ['.ts', '.js'],
@@ -21,7 +22,7 @@ const baseConfig: webpack.Configuration = {
       {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: /node_modules/
+        exclude: /node_modules/,
       },
     ],
   },
@@ -39,20 +40,11 @@ const baseConfig: webpack.Configuration = {
 
 export const browserConfig: webpack.Configuration = merge(baseConfig, {
   entry: './src/browser.ts',
-  output: {
-    filename: 'browser.js',
-  },
 });
 
 export const nodeConfig: webpack.Configuration = merge(baseConfig, {
   entry: './src/node.ts',
-  output: {
-    filename: 'node.js',
-  },
-  target: 'node'
+  target: 'node',
 });
 
-export default [
-  browserConfig,
-  nodeConfig,
-];
+export default { browserConfig, nodeConfig };

--- a/packages/nitro-client/webpack.dev.ts
+++ b/packages/nitro-client/webpack.dev.ts
@@ -1,13 +1,20 @@
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import commonConfigs from './webpack.common';
+import { browserConfig, nodeConfig } from './webpack.common';
 
-const devConfigs: webpack.Configuration[] = commonConfigs.map(
-  (config) => merge(config, {
-    mode: 'development',
-    devtool: 'source-map',
-  }),
-);
+const devConfig: webpack.Configuration = {
+  mode: 'development',
+  devtool: 'source-map',
+};
 
-export default devConfigs;
+const devBrowserConfig: webpack.Configuration = merge(browserConfig, devConfig);
+const devNodeConfig: webpack.Configuration = merge(nodeConfig, devConfig);
+
+export default (env: { [key: string]: string | boolean }) => {
+  if (env.target === 'browser') {
+    return devBrowserConfig;
+  }
+
+  return devNodeConfig;
+};

--- a/packages/nitro-client/webpack.dev.ts
+++ b/packages/nitro-client/webpack.dev.ts
@@ -1,11 +1,13 @@
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import baseConfig from './webpack.common';
+import commonConfigs from './webpack.common';
 
-const config: webpack.Configuration = merge(baseConfig, {
-  mode: 'development',
-  devtool: 'source-map',
-});
+const devConfigs: webpack.Configuration[] = commonConfigs.map(
+  (config) => merge(config, {
+    mode: 'development',
+    devtool: 'source-map',
+  }),
+);
 
-export default config;
+export default devConfigs;

--- a/packages/nitro-client/webpack.prod.ts
+++ b/packages/nitro-client/webpack.prod.ts
@@ -1,15 +1,22 @@
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import commonConfigs from './webpack.common';
+import { browserConfig, nodeConfig } from './webpack.common';
 
-const prodConfigs: webpack.Configuration[] = commonConfigs.map(
-  (config) => merge(config, {
-    mode: 'production',
-    optimization: {
-      // Add production-specific optimizations here
-    },
-  }),
-);
+const prodConfig: webpack.Configuration = {
+  mode: 'production',
+  optimization: {
+    // Add production-specific optimizations here
+  },
+};
 
-export default prodConfigs;
+const prodBrowserConfig = merge(browserConfig, prodConfig);
+const prodNodeConfig = merge(nodeConfig, prodConfig);
+
+export default (env: { [key: string]: string | boolean }) => {
+  if (env.target === 'browser') {
+    return prodBrowserConfig;
+  }
+
+  return prodNodeConfig;
+};

--- a/packages/nitro-client/webpack.prod.ts
+++ b/packages/nitro-client/webpack.prod.ts
@@ -1,13 +1,15 @@
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import baseConfig from './webpack.common';
+import commonConfigs from './webpack.common';
 
-const config: webpack.Configuration = merge(baseConfig, {
-  mode: 'production',
-  optimization: {
-    // Add production-specific optimizations here
-  },
-});
+const prodConfigs: webpack.Configuration[] = commonConfigs.map(
+  (config) => merge(config, {
+    mode: 'production',
+    optimization: {
+      // Add production-specific optimizations here
+    },
+  }),
+);
 
-export default config;
+export default prodConfigs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,6 @@
   resolved "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz"
   integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
 
-"@adraffy/ens-normalize@https://github.com/ricmoo/ens-normalize.js":
-  version "1.9.0"
-  resolved "https://github.com/ricmoo/ens-normalize.js#2d040533e57e4f25f9a7cc4715e219658ad454b5"
-
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
@@ -1307,6 +1303,348 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
   integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
 
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
+"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/contracts@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
+  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
+  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
+  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+
+"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@5.7.2":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
+  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
+"@ethersproject/units@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
+  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/wallet@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
+  integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/json-wallets" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
+  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
@@ -2161,12 +2499,7 @@
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
   integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
-"@noble/hashes@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
-  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
-
-"@noble/secp256k1@1.7.1", "@noble/secp256k1@^1.5.4":
+"@noble/secp256k1@^1.5.4":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
@@ -3159,11 +3492,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.1.tgz#de559d4b33be9a808fd43372ccee822c70f39704"
   integrity sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==
 
-"@types/node@18.15.13":
-  version "18.15.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
-  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
-
 "@types/node@>=13.7.0", "@types/node@^20.2.1":
   version "20.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.3.tgz#b31eb300610c3835ac008d690de6f87e28f9b878"
@@ -3693,10 +4021,10 @@ adjust-sourcemap-loader@^4.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
-aes-js@4.0.0-beta.5:
-  version "4.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
-  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -4200,6 +4528,11 @@ batch@0.6.1:
   resolved "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
 before-after-hook@^2.2.0:
   version "2.2.3"
   resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz"
@@ -4248,6 +4581,16 @@ bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.20.1:
   version "1.20.1"
@@ -4303,6 +4646,11 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+brorand@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -5680,6 +6028,19 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.401.tgz"
   integrity sha512-AswqHsYyEbfSn0x87n31Na/xttUqEAg7NUjpiyxC20MaWKLyadOYHMzyLdF78N1iw+FK8/2KHLpZxRdyRILgtA==
 
+elliptic@6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emittery@^0.10.2:
   version "0.10.2"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz"
@@ -6286,18 +6647,41 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethers@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.4.0.tgz#82c230a3a018a2627593d24ec4b9c20e9681c341"
-  integrity sha512-nksaMCwX+BOdV2NQ1/57OehSD2JtujbhrdC2+Fb9VpvBO0WO6h+WWwu3oMMw7aUiTa5lvQcWX1vl4aOy7Q3CTg==
+ethers@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
+  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
   dependencies:
-    "@adraffy/ens-normalize" "https://github.com/ricmoo/ens-normalize.js"
-    "@noble/hashes" "1.1.2"
-    "@noble/secp256k1" "1.7.1"
-    "@types/node" "18.15.13"
-    aes-js "4.0.0-beta.5"
-    tslib "2.4.0"
-    ws "8.5.0"
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.1"
+    "@ethersproject/wordlists" "5.7.0"
 
 event-iterator@^2.0.0:
   version "2.0.0"
@@ -7161,10 +7545,27 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hmac-drbg@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 hoopy@^0.1.4:
   version "0.1.4"
@@ -8596,6 +8997,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
   integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -9380,10 +9786,15 @@ mini-css-extract-plugin@^2.4.5:
   dependencies:
     schema-utils "^4.0.0"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@3.0.5:
   version "3.0.5"
@@ -12058,6 +12469,11 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
@@ -13063,11 +13479,6 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
@@ -14049,10 +14460,10 @@ write-pkg@4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^7.4.6:
   version "7.5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,21 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/is-ip/-/is-ip-2.0.1.tgz#62cb285669d91f88fd9fa285048dde3882f0993b"
   integrity sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ==
 
+"@chainsafe/libp2p-yamux@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz#2e970da83cda5551c834fb786963007a71e772f1"
+  integrity sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==
+  dependencies:
+    "@libp2p/interface-connection" "^5.1.0"
+    "@libp2p/interface-stream-muxer" "^4.1.2"
+    "@libp2p/interfaces" "^3.3.2"
+    "@libp2p/logger" "^2.0.7"
+    abortable-iterator "^5.0.1"
+    any-signal "^4.1.1"
+    it-pipe "^3.0.1"
+    it-pushable "^3.1.3"
+    uint8arraylist "^2.4.3"
+
 "@chainsafe/netmask@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/netmask/-/netmask-2.0.0.tgz#0d4a75f47919f65011da4327a3845c9661f1038a"
@@ -1780,7 +1795,7 @@
     "@libp2p/peer-collections" "^3.0.1"
     "@multiformats/multiaddr" "^12.0.0"
 
-"@libp2p/interface-connection@^5.0.0", "@libp2p/interface-connection@^5.0.1":
+"@libp2p/interface-connection@^5.0.0", "@libp2p/interface-connection@^5.0.1", "@libp2p/interface-connection@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@libp2p/interface-connection/-/interface-connection-5.1.0.tgz#dd5e5f5b0d0fec2b5b2324439f64209db910f21b"
   integrity sha512-KFjCnGvFVlu0hHS/O8NOsst32mIzUQEkRWq5EhOBehXjjpOJBcm8XQaqmhBlxVfHEYm7XQsztEtFumveszzm1A==
@@ -1905,7 +1920,7 @@
     "@libp2p/interface-connection" "^5.0.0"
     "@libp2p/interface-peer-id" "^2.0.0"
 
-"@libp2p/interface-stream-muxer@^4.0.0":
+"@libp2p/interface-stream-muxer@^4.0.0", "@libp2p/interface-stream-muxer@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz#f0a5edb906ec784d991b9421a024f0f21ebdaab4"
   integrity sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==
@@ -1930,7 +1945,7 @@
     "@multiformats/multiaddr" "^12.0.0"
     it-stream-types "^2.0.1"
 
-"@libp2p/interfaces@^3.0.0", "@libp2p/interfaces@^3.2.0", "@libp2p/interfaces@^3.3.1":
+"@libp2p/interfaces@^3.0.0", "@libp2p/interfaces@^3.2.0", "@libp2p/interfaces@^3.3.1", "@libp2p/interfaces@^3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@libp2p/interfaces/-/interfaces-3.3.2.tgz#5d8079be845b0960939b5b18880e785a4714465a"
   integrity sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==
@@ -2065,6 +2080,21 @@
     uint8arraylist "^2.1.1"
     uint8arrays "^4.0.2"
 
+"@libp2p/tcp@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@libp2p/tcp/-/tcp-7.0.1.tgz#116b311deb89e70a04ab31f70c783f2224ef3d48"
+  integrity sha512-But+0FiTBNjIpFeYMpq5QetSLK0MKQaRjDYsYC0AUIE61TmrWE4tpxnW57rl/hKJprVbYs/9lYxgflL9Mo33Wg==
+  dependencies:
+    "@libp2p/interface-connection" "^5.0.0"
+    "@libp2p/interface-metrics" "^4.0.0"
+    "@libp2p/interface-transport" "^4.0.0"
+    "@libp2p/interfaces" "^3.2.0"
+    "@libp2p/logger" "^2.0.0"
+    "@libp2p/utils" "^3.0.2"
+    "@multiformats/mafmt" "^12.0.0"
+    "@multiformats/multiaddr" "^12.0.0"
+    stream-to-it "^0.2.2"
+
 "@libp2p/topology@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@libp2p/topology/-/topology-4.0.1.tgz#8efab229ed32d30cfa6c4a371e8022011c0ff6f9"
@@ -2082,7 +2112,7 @@
   dependencies:
     "@libp2p/interface-metrics" "^4.0.0"
 
-"@libp2p/utils@^3.0.0", "@libp2p/utils@^3.0.10":
+"@libp2p/utils@^3.0.0", "@libp2p/utils@^3.0.10", "@libp2p/utils@^3.0.2":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@libp2p/utils/-/utils-3.0.11.tgz#d1611c3d7836eb32e5fc8bcc19c620e77471f44f"
   integrity sha512-d8ZQnu2o78TG7Oy4G6qFy5v/kNBtfgQjy1RpiQAEAB6AOSi1Oq8nLebrgCqSHfrtOIcj6a+G6ImYBaRE4b03CA==
@@ -5894,7 +5924,7 @@ eslint-config-airbnb-typescript@^17.0.0:
 
 eslint-config-react-app@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz#73ba3929978001c5c86274c017ea57eb5fa644b4"
   integrity sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==
   dependencies:
     "@babel/core" "^7.16.0"
@@ -6770,6 +6800,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has "^1.0.3"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
+
+get-iterator@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-iterator/-/get-iterator-1.0.2.tgz#cd747c02b4c084461fac14f48f6b45a80ed25c82"
+  integrity sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==
 
 get-iterator@^2.0.0:
   version "2.0.0"
@@ -12418,6 +12453,13 @@ stop-iteration-iterator@^1.0.0:
   integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
   dependencies:
     internal-slot "^1.0.4"
+
+stream-to-it@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.4.tgz#d2fd7bfbd4a899b4c0d6a7e6a533723af5749bd0"
+  integrity sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==
+  dependencies:
+    get-iterator "^1.0.2"
 
 streamsearch@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Setup separate builds for browser and Node.js environments
- Add implementation for `newMessageService` method in `P2PMessageService` to instantiate class
- Downgrade ethers.js library to v5 for using in browser