### PR TITLE
Port `ObjectiveRequest.Response` implementation required for direct-fund command

### DIFF
--- a/packages/nitro-client/src/browser.ts
+++ b/packages/nitro-client/src/browser.ts
@@ -3,7 +3,7 @@ export { EthChainService } from './client/engine/chainservice/eth-chainservice';
 export { MemStore } from './client/engine/store/memstore';
 export { PermissivePolicy } from './client/engine/policy-maker';
 export { SingleAssetExit, Exit } from './channel/state/outcome/exit';
-export { Allocation } from './channel/state/outcome/allocation';
+export { Allocation, AllocationType, Allocations } from './channel/state/outcome/allocation';
 export { Destination } from './types/destination';
 
 export const test = (): string => {

--- a/packages/nitro-client/src/channel/channel.ts
+++ b/packages/nitro-client/src/channel/channel.ts
@@ -18,7 +18,7 @@ interface ConstructorOptions extends FixedPartConstructorOptions {
 
 // Channel contains states and metadata and exposes convenience methods.
 export class Channel extends FixedPart {
-  id: Destination = new Destination('');
+  id: Destination = new Destination();
 
   // TODO: unit replacement
   myIndex: number = 0;

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -20,7 +20,7 @@ export const Follower: LedgerIndex = 1;
 // of type 0, ie. a simple allocation.
 // TODO: Implement
 export class Balance {
-  private destination: Destination = new Destination('');
+  private destination: Destination = new Destination();
 
   private amount: bigint = BigInt(0);
 
@@ -48,11 +48,11 @@ export class Balance {
 export class Guarantee {
   private amount: bigint = BigInt(0);
 
-  private target: Destination = new Destination('');
+  private target: Destination = new Destination();
 
-  private left: Destination = new Destination('');
+  private left: Destination = new Destination();
 
-  private right: Destination = new Destination('');
+  private right: Destination = new Destination();
 
   constructor(params: {
     amount: bigint;

--- a/packages/nitro-client/src/channel/state/outcome/allocation.ts
+++ b/packages/nitro-client/src/channel/state/outcome/allocation.ts
@@ -8,7 +8,7 @@ export enum AllocationType {
 // Allocation declares an Amount to be paid to a Destination.
 export class Allocation {
   // Either an ethereum address or an application-specific identifier
-  destination: Destination = new Destination('');
+  destination: Destination = new Destination();
 
   // An amount of a particular asset
   amount: bigint = BigInt(0);

--- a/packages/nitro-client/src/channel/state/outcome/guarantee.ts
+++ b/packages/nitro-client/src/channel/state/outcome/guarantee.ts
@@ -1,9 +1,9 @@
 import { Destination } from '../../../types/destination';
 
 export class GuaranteeMetadata {
-  left: Destination = new Destination('');
+  left: Destination = new Destination();
 
-  right: Destination = new Destination('');
+  right: Destination = new Destination();
 
   // Decode returns a GuaranteeMetaData from an abi encoding
   static decodeIntoGuaranteeMetadata(m: Buffer): GuaranteeMetadata {

--- a/packages/nitro-client/src/client/query/types.ts
+++ b/packages/nitro-client/src/client/query/types.ts
@@ -40,7 +40,7 @@ export class PaymentChannelBalance {
 
 // PaymentChannelInfo contains balance and status info about a payment channel
 export class PaymentChannelInfo {
-  iD: Destination = new Destination('');
+  iD: Destination = new Destination();
 
   status: ChannelStatus = ChannelStatus.Proposed;
 
@@ -90,7 +90,7 @@ export class LedgerChannelBalance {
 
 // LedgerChannelInfo contains balance and status info about a ledger channel
 export class LedgerChannelInfo {
-  iD = new Destination('');
+  iD = new Destination();
 
   status: ChannelStatus = ChannelStatus.Proposed;
 

--- a/packages/nitro-client/src/node.ts
+++ b/packages/nitro-client/src/node.ts
@@ -4,5 +4,5 @@ export { P2PMessageService } from './client/engine/messageservice/p2p-message-se
 export { MemStore } from './client/engine/store/memstore';
 export { PermissivePolicy } from './client/engine/policy-maker';
 export { SingleAssetExit, Exit } from './channel/state/outcome/exit';
-export { Allocation } from './channel/state/outcome/allocation';
+export { Allocation, AllocationType, Allocations } from './channel/state/outcome/allocation';
 export { Destination } from './types/destination';

--- a/packages/nitro-client/src/types/destination.ts
+++ b/packages/nitro-client/src/types/destination.ts
@@ -1,4 +1,5 @@
 import { Bytes32, isExternalDestination } from '@statechannels/nitro-protocol';
+import { ethers } from 'ethers';
 import { Address } from './types';
 
 // Destination represents a payable address in go-nitro. In a state channel network,
@@ -10,7 +11,7 @@ export class Destination {
   // Can use prototype.valueOf method if necessary
   value: Bytes32;
 
-  constructor(value: Bytes32) {
+  constructor(value: Bytes32 = ethers.utils.hexZeroPad([], 32)) {
     this.value = value;
   }
 

--- a/packages/server/test-e2e/utils.ts
+++ b/packages/server/test-e2e/utils.ts
@@ -1,5 +1,5 @@
 import {
-  Allocation, Destination, Exit, SingleAssetExit,
+  Allocation, Destination, Exit, SingleAssetExit, AllocationType,
 } from '@cerc-io/nitro-client';
 
 /**
@@ -32,26 +32,26 @@ export function createOutcome(
   amount: number,
 ): Exit {
   return new Exit([
-    new SingleAssetExit(
+    new SingleAssetExit({
       asset,
-      {
+      assetMetadata: {
         assetType: 0,
         metadata: Buffer.alloc(0),
       },
-      [
-        new Allocation(
-          Destination.addressToDestination(convertAddressToBytes32(alpha)),
-          BigInt(amount),
-          0,
-          Buffer.alloc(0),
-        ),
-        new Allocation(
-          Destination.addressToDestination(convertAddressToBytes32(beta)),
-          BigInt(amount),
-          0,
-          Buffer.alloc(0),
-        ),
+      allocations: [
+        new Allocation({
+          destination: Destination.addressToDestination(convertAddressToBytes32(alpha)),
+          amount: BigInt(amount),
+          allocationType: AllocationType.NormalAllocationType,
+          metadata: Buffer.alloc(0),
+        }),
+        new Allocation({
+          destination: Destination.addressToDestination(convertAddressToBytes32(beta)),
+          amount: BigInt(amount),
+          allocationType: AllocationType.NormalAllocationType,
+          metadata: Buffer.alloc(0),
+        }),
       ],
-    ),
+    }),
   ]);
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Set zero/default value of Address type to 32 length hexstring
- Implement `ObjectiveRequest.Response` method
- Fix types in e2e test util