### PR TITLE
Port implementation for `Engine.registerPaymentChannel` in virtual-fund command

### DIFF
--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -30,7 +30,7 @@ import { VirtualChannel } from '../../channel/virtual';
 import {
   constructLedgerInfoFromChannel, constructLedgerInfoFromConsensus, constructPaymentInfo, getVoucherBalance,
 } from '../query/query';
-import { PAYER_INDEX } from '../../payments/helpers';
+import { PAYER_INDEX, getPayee, getPayer } from '../../payments/helpers';
 
 const JSONbigNative = JSONbig({ useNativeBigInt: true });
 const log = debug('ts-nitro:client');
@@ -495,9 +495,21 @@ export class Engine {
     return outgoing;
   }
 
-  // TODO: Can throw an error
   private registerPaymentChannel(vfo: VirtualFundObjective): void {
-    // TODO: Implement
+    assert(vfo.v);
+    const postfund = vfo.v.postFundState();
+
+    // TODO: Assumes one asset for now
+    const startingBalance = BigInt(postfund.outcome.value[0].allocations[0].amount);
+
+    assert(this.vm);
+
+    return this.vm.register(
+      vfo.v.id,
+      getPayer(postfund.participants),
+      getPayee(postfund.participants),
+      startingBalance,
+    );
   }
 
   // spawnConsensusChannelIfDirectFundObjective will attempt to create and store a ConsensusChannel derived from

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -1,6 +1,7 @@
 import { bytes2Hex } from '@cerc-io/nitro-util';
 
 import { ethers } from 'ethers';
+import assert from 'assert';
 import { Store } from './store';
 import { Objective, ObjectiveStatus } from '../../../protocols/interfaces';
 import { Channel } from '../../../channel/channel';
@@ -204,15 +205,29 @@ export class MemStore implements Store {
     this.channelToObjective.delete(channelId.string());
   }
 
-  // TODO: Implement
   setVoucherInfo(channelId: Destination, v: VoucherInfo): void {
-    // TODO: Implement
+    // Implement json.Marshal
+    const jsonData = Buffer.from(JSON.stringify(v));
+
+    this.vouchers.store(channelId.string(), jsonData);
   }
 
   // TODO: Implement
-  getVoucherInfo(channelId: Destination): VoucherInfo {
-    // TODO: Implement
-    return {} as VoucherInfo;
+  getVoucherInfo(channelId: Destination): [VoucherInfo | undefined, boolean] {
+    const [data, ok] = this.vouchers.load(channelId.string());
+    if (!ok) {
+      return [undefined, false];
+    }
+
+    assert(data);
+
+    try {
+      // TODO: Implement json.Unmarshal
+      const v = new VoucherInfo(JSON.parse(data.toString()));
+      return [v, true];
+    } catch (err) {
+      return [undefined, false];
+    }
   }
 
   // TODO: Implement

--- a/packages/nitro-client/src/payments/helpers.ts
+++ b/packages/nitro-client/src/payments/helpers.ts
@@ -6,4 +6,4 @@ export const PAYER_INDEX = 0;
 export const getPayer = (participants: Address[]): Address => participants[PAYER_INDEX];
 
 // GetPayee returns the payee on a payment channel
-const getPayee = (participants: Address[]): Address => participants[participants.length - 1];
+export const getPayee = (participants: Address[]): Address => participants[participants.length - 1];

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -9,7 +9,7 @@ export interface VoucherStore {
   setVoucherInfo (channelId: Destination, v: VoucherInfo): void
 
   // TODO: Can throw an error
-  getVoucherInfo (channelId: Destination): VoucherInfo
+  getVoucherInfo (channelId: Destination): [VoucherInfo | undefined, boolean]
 
   // TODO: Can throw an error
   removeVoucherInfo (channelId: Destination): void
@@ -34,7 +34,6 @@ export class VoucherManager {
   }
 
   // Register registers a channel for use, given the payer, payee and starting balance of the channel
-  // TODO: Can throw an error
   register(channelId: Destination, payer: string, payee: string, startingBalance: bigint): void {
     const voucher = new Voucher({ channelId, amount: BigInt(0) });
     const data = new VoucherInfo({
@@ -45,13 +44,12 @@ export class VoucherManager {
     });
 
     // TODO: Implement
-    const v = this.store.getVoucherInfo(channelId);
+    const [v] = this.store.getVoucherInfo(channelId);
     if (!v) {
       throw new Error('Channel already registered');
     }
 
-    // TODO: Implement
-    return this.store.setVoucherInfo(channelId, data);
+    this.store.setVoucherInfo(channelId, data);
   }
 
   // Remove deletes the channel's status

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -36,7 +36,22 @@ export class VoucherManager {
   // Register registers a channel for use, given the payer, payee and starting balance of the channel
   // TODO: Can throw an error
   register(channelId: Destination, payer: string, payee: string, startingBalance: bigint): void {
+    const voucher = new Voucher({ channelId, amount: BigInt(0) });
+    const data = new VoucherInfo({
+      channelPayer: payer,
+      channelPayee: payee,
+      startingBalance: BigInt(startingBalance),
+      largestVoucher: voucher,
+    });
+
     // TODO: Implement
+    const v = this.store.getVoucherInfo(channelId);
+    if (!v) {
+      throw new Error('Channel already registered');
+    }
+
+    // TODO: Implement
+    return this.store.setVoucherInfo(channelId, data);
   }
 
   // Remove deletes the channel's status
@@ -47,7 +62,7 @@ export class VoucherManager {
   // total amount paid.
   // TODO: Can throw an error
   pay(channelId: string, amount: bigint, pk: string): Voucher {
-    return new Voucher();
+    return new Voucher({});
   }
 
   // Receive validates the incoming voucher, and returns the total amount received so far

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -9,15 +9,25 @@
 //     {alice: 80, bob: 20}
 
 import { ethers } from 'ethers';
-import { Signature } from '../crypto/signatures';
+
+import { Signature } from '../channel/state/state';
 import { Address } from '../types/types';
+import { Destination } from '../types/destination';
 
 export class Voucher {
-  channelId?: string;
+  channelId: Destination = new Destination();
 
   amount?: bigint;
 
-  signature?: Signature;
+  signature: Signature = {};
+
+  constructor(params: {
+    channelId?: Destination;
+    amount?: bigint;
+    signature?: Signature;
+  }) {
+    Object.assign(this, params);
+  }
 
   // TODO: Can throw an error
   // TODO: Implement
@@ -46,13 +56,22 @@ export class Voucher {
 // As well as details about the balance and who the payee/payer is.
 // TODO: Implement
 export class VoucherInfo {
-  channelPayer?: string;
+  channelPayer: Address = ethers.constants.AddressZero;
 
-  channelPayee?: string;
+  channelPayee: Address = ethers.constants.AddressZero;
 
   startingBalance?: bigint;
 
-  largestVoucher?: Voucher;
+  largestVoucher: Voucher = new Voucher({});
+
+  constructor(params: {
+    channelPayer: Address
+    channelPayee: Address
+    startingBalance?: bigint
+    largestVoucher: Voucher
+  }) {
+    Object.assign(this, params);
+  }
 
   // Paid is the amount of funds that already have been used as payments
   paid(): bigint {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port `VoucherManager.register` method
- Port `MemStore.getVoucherInfo` method
- Port `MemStore.setVoucherInfo` method