### PR TITLE
Port method implementations for `get-payment-channel` command

### DIFF
--- a/packages/nitro-client/src/channel/channel.ts
+++ b/packages/nitro-client/src/channel/channel.ts
@@ -87,7 +87,15 @@ export class Channel extends FixedPart {
   // json-encoded data
   // TODO: Can throw an error
   // TODO: Implement
-  UnmarshalJSON(data: Buffer): void {}
+  unmarshalJSON(data: Buffer): void {
+    try {
+      // TODO: Implement json.Unmarshal
+      const jsonCh = JSON.parse(data.toString());
+      Object.assign(this, jsonCh);
+    } catch (err) {
+      throw new Error('error unmarshaling channel data');
+    }
+  }
 
   // MyDestination returns the client's destination
   // TODO: Implement

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -2,7 +2,7 @@ import { bytes2Hex } from '@cerc-io/nitro-util';
 
 import { ethers } from 'ethers';
 import assert from 'assert';
-import { Store } from './store';
+import { ErrNoSuchChannel, Store } from './store';
 import { Objective, ObjectiveStatus } from '../../../protocols/interfaces';
 import { Channel } from '../../../channel/channel';
 import { ConsensusChannel } from '../../../channel/consensus-channel/consensus-channel';
@@ -150,13 +150,33 @@ export class MemStore implements Store {
   destroyConsensusChannel(id: string): void {}
 
   getChannelById(id: Destination): [Channel, boolean] {
-    // TODO: Implement
-    return [{} as Channel, false];
+    try {
+      const ch = this._getChannelById(id);
+
+      return [ch, true];
+    } catch (err) {
+      return [new Channel({}), false];
+    }
   }
 
   private _getChannelById(id: Destination): Channel {
-    // TODO: Implement
-    return {} as Channel;
+    const [chJSON, ok] = this.channels.load(id.toString());
+
+    if (!ok) {
+      throw ErrNoSuchChannel;
+    }
+
+    assert(chJSON);
+
+    const ch = new Channel({});
+
+    try {
+      ch.unmarshalJSON(chJSON);
+
+      return ch;
+    } catch (err) {
+      throw new Error(`error unmarshaling channel ${ch.id}`);
+    }
   }
 
   // TODO: Implement

--- a/packages/nitro-client/src/client/engine/store/store.ts
+++ b/packages/nitro-client/src/client/engine/store/store.ts
@@ -5,6 +5,8 @@ import { VoucherStore } from '../../../payments/voucher-manager';
 import { Address } from '../../../types/types';
 import { Destination } from '../../../types/destination';
 
+export const ErrNoSuchChannel = new Error('store: failed to find required channel data');
+
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 export interface Store extends ConsensusChannelStore, VoucherStore {
   // Get a pointer to a secret key for signing channel updates


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port `query.getPaymentChannelInfo` method
- Port `MemStore.getChannelById` method