### PR TITLE
Port implementation for `Voucher.sign` method in pay command

### DIFF
--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import { ethers } from 'ethers';
 
+import { zeroValueSignature } from '@cerc-io/nitro-util';
+
 import { Signature } from '../../crypto/signatures';
 import { Address } from '../../types/types';
 import { Funds } from '../../types/funds';
@@ -229,7 +231,10 @@ export class Vars {
 export class SignedVars {
   vars?: Vars;
 
-  signatures: [Signature, Signature] = [{}, {}];
+  signatures: [Signature, Signature] = [
+    zeroValueSignature,
+    zeroValueSignature,
+  ];
 
   constructor(params: {
     vars?: Vars;
@@ -441,7 +446,7 @@ export class ConsensusChannel {
   // TODO: Can throw an error
   // TODO: Implement
   private sign(vars: Vars, sk: Buffer): Signature {
-    return {};
+    return zeroValueSignature;
   }
 
   // recoverSigner returns the signer of the vars using the given signature.
@@ -461,7 +466,10 @@ export class ConsensusChannel {
   // Signatures returns the signatures on the currently supported state.
   // TODO: Implement
   signatures(): [Signature, Signature] {
-    return [{}, {}];
+    return [
+      zeroValueSignature,
+      zeroValueSignature,
+    ];
   }
 
   // ProposalQueue returns the current queue of proposals, ordered by TurnNum.

--- a/packages/nitro-client/src/channel/state/signedstate.ts
+++ b/packages/nitro-client/src/channel/state/signedstate.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
 
+import { zeroValueSignature } from '@cerc-io/nitro-util';
+
 import { Signature } from '../../crypto/signatures';
 import { State } from './state';
 
@@ -65,7 +67,7 @@ export class SignedState {
   // TODO: Can throw an error
   // TODO: Implement
   getParticipantSignature(participantIndex: number): Signature {
-    return false;
+    return zeroValueSignature;
   }
 
   // Merge checks the passed SignedState's state and the receiver's state for equality, and adds each signature from the former to the latter.

--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 
 import { getChannelId as utilGetChannelId } from '@statechannels/nitro-protocol';
+import { zeroValueSignature } from '@cerc-io/nitro-util';
 
 import * as nc from '../../crypto/signatures';
 import { Address } from '../../types/types';
@@ -143,9 +144,9 @@ export class State {
   // The state hash is prepended with \x19Ethereum Signed Message:\n32 and then rehashed
   // to create a digest to sign
   // TODO: Can throw an error
-  // TODO: Implement
   sign(secretKey: Buffer): Signature {
-    return {};
+    // TODO: Implement
+    return zeroValueSignature;
   }
 
   // RecoverSigner computes the Ethereum address which generated Signature sig on State state

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -373,7 +373,6 @@ export class Engine {
     const cId = request.channelId;
     let voucher: Voucher;
     try {
-      // TODO: Implement
       voucher = this.vm!.pay(cId, request.amount, this.store!.getChannelSecretKey());
     } catch (err) {
       throw new Error(`handleAPIEvent: Error making payment: ${err}`);

--- a/packages/nitro-client/src/crypto/signatures.ts
+++ b/packages/nitro-client/src/crypto/signatures.ts
@@ -1,6 +1,26 @@
 // Signature is an ECDSA signature
-// TODO: Add fields
-export type Signature = {};
+
+import { ethers } from 'ethers';
+
+export type Signature = {
+  r: string;
+  s: string;
+  v: number;
+};
+
+// computeEthereumSignedMessageDigest accepts an arbitrary message, prepends a known message,
+// and hashes the result using keccak256. The known message added to the input before hashing is
+// "\x19Ethereum Signed Message:\n" + len(message).
+const computeEthereumSignedMessageDigest = (message: Buffer): Buffer => {
+  const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
+  const prefixBytes = ethers.utils.toUtf8Bytes(prefix);
+  const messageBytes = ethers.utils.arrayify(message);
+  const formattedMessage = ethers.utils.concat([prefixBytes, messageBytes]);
+  return Buffer.from(ethers.utils.keccak256(formattedMessage));
+};
+
+// splitSignature takes a 65 bytes signature in the [R||S||V] format and returns the individual components
+const splitSignature = (concatenatedSignature: Buffer): Signature => ethers.utils.splitSignature(concatenatedSignature);
 
 // SignEthereumMessage accepts an arbitrary message, prepends a known message,
 // hashes the result using keccak256 and calculates the secp256k1 signature
@@ -8,13 +28,17 @@ export type Signature = {};
 // "\x19Ethereum Signed Message:\n" + len(message).
 // See https://github.com/ethereum/go-ethereum/pull/2940 and EIPs 191, 721.
 // TODO: Implement
-export const signEthereumMessage = (message: Buffer, secretKey: Buffer): Signature => ({});
+export const signEthereumMessage = async (message: Buffer, secretKey: Buffer): Promise<Signature> => {
+  const digest = computeEthereumSignedMessageDigest(message);
+  const wallet = new ethers.Wallet(secretKey);
+  const concatenatedSignature = await wallet.signMessage(digest);
 
-// computeEthereumSignedMessageDigest accepts an arbitrary message, prepends a known message,
-// and hashes the result using keccak256. The known message added to the input before hashing is
-// "\x19Ethereum Signed Message:\n" + len(message).
-// TODO: Implement
-const computeEthereumSignedMessageDigest = (message: Buffer): Buffer => Buffer.alloc(0);
+  const sig = splitSignature(Buffer.from(concatenatedSignature));
 
-// splitSignature takes a 65 bytes signature in the [R||S||V] format and returns the individual components
-const splitSignature = (concatenatedSignature: Buffer): Signature => ({});
+  // This step is necessary to remain compatible with the ecrecover precompile
+  if (sig.v < 27) {
+    sig.v += 27;
+  }
+
+  return sig;
+};

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -81,7 +81,6 @@ export class VoucherManager {
 
     vInfo.largestVoucher = voucher;
 
-    // TODO: Implement
     voucher.sign(pk);
 
     this.store.setVoucherInfo(channelId, vInfo);

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -10,6 +10,9 @@
 
 import { ethers } from 'ethers';
 
+import { signVoucher } from '@statechannels/nitro-protocol';
+import { zeroValueSignature } from '@cerc-io/nitro-util';
+
 import { Signature } from '../channel/state/state';
 import { Address } from '../types/types';
 import { Destination } from '../types/destination';
@@ -19,7 +22,7 @@ export class Voucher {
 
   amount?: bigint;
 
-  signature: Signature = {};
+  signature: Signature = zeroValueSignature;
 
   constructor(params: {
     channelId?: Destination;
@@ -35,9 +38,17 @@ export class Voucher {
     return Buffer.from('');
   }
 
-  // TODO: Can throw an error
-  sign(pk: Buffer): void {
-    // TODO: Implement
+  async sign(pk: Buffer): Promise<void> {
+    const wallet = new ethers.Wallet(pk);
+
+    // Using util method from nitro-protocol instead of go-nitro port
+    this.signature = await signVoucher(
+      {
+        amount: this.amount!.toString(),
+        channelId: this.channelId.string(),
+      },
+      wallet,
+    );
   }
 
   // TODO: Can throw an error

--- a/packages/nitro-util/src/hex-utils.ts
+++ b/packages/nitro-util/src/hex-utils.ts
@@ -1,3 +1,11 @@
+import { ethers } from 'ethers';
+
+export const zeroValueSignature = {
+  v: 27, // Choose a valid value for v (27 or 28)
+  r: ethers.constants.HashZero, // Set r to a 32-byte zero value
+  s: ethers.constants.HashZero, // Set s to a 32-byte zero value
+};
+
 // Bytes2Hex returns the hexadecimal encoding of d.
 export function bytes2Hex(d: Buffer): string {
   return d.toString('hex');


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Use `signVoucher` util method from nitro-protocol package
- Port implementations for `SignEthereumMessage` method