### PR TITLE
Add placeholder methods for `virtual-defund` command

### DIFF
--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -150,6 +150,12 @@ export class Client {
     return objectiveRequest.response(this.address);
   }
 
+  // CloseVirtualChannel attempts to close and defund the given virtually funded channel.
+  closeVirtualChannel(channelId: Destination): ObjectiveId {
+    // TODO: Implement
+    return '';
+  }
+
   // Pay will send a signed voucher to the payee that they can redeem for the given amount.
   pay(channelId: Destination, amount: bigint) {
     assert(this.engine.paymentRequestsFromAPI);

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -401,7 +401,6 @@ export class Engine {
     ee.paymentChannelUpdates = [...ee.paymentChannelUpdates, info];
 
     const se = new SideEffects({
-      // TODO: Implement
       messagesToSend: Message.createVoucherMessage(voucher, payee),
     });
 

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -24,7 +24,7 @@ import { Voucher } from '../../payments/vouchers';
 import { LedgerChannelInfo, PaymentChannelInfo } from '../query/types';
 import { ObjectiveRequest as DirectDefundObjectiveRequest } from '../../protocols/directdefund/directdefund';
 import { ObjectiveRequest as DirectFundObjectiveRequest, Objective as DirectFundObjective } from '../../protocols/directfund/directfund';
-import { ObjectiveRequest as VirtualDefundObjectiveRequest } from '../../protocols/virtualdefund/virtualdefund';
+import { ObjectiveRequest as VirtualDefundObjectiveRequest, Objective as VirtualDefundObjective } from '../../protocols/virtualdefund/virtualdefund';
 import * as channel from '../../channel/channel';
 import { VirtualChannel } from '../../channel/virtual';
 import {
@@ -331,9 +331,36 @@ export class Engine {
         return this.attemptProgress(vfo);
       }
 
-      case or instanceof VirtualDefundObjectiveRequest:
-        // TODO: Implement
-        break;
+      case or instanceof VirtualDefundObjectiveRequest: {
+        let minAmount = BigInt(0);
+        const virtualDefundOR = or as VirtualDefundObjectiveRequest;
+
+        if (this.vm!.channelRegistered(virtualDefundOR.channelId)) {
+          try {
+            const paid = this.vm!.paid(virtualDefundOR.channelId);
+
+            minAmount = paid;
+          } catch (err) {
+            throw new Error(`handleAPIEvent: Could not create objective for ${JSON.stringify(virtualDefundOR)}: ${err}`);
+          }
+        }
+
+        try {
+          const vdfo = VirtualDefundObjective.newObjective(
+            virtualDefundOR,
+            true,
+            myAddress,
+            minAmount,
+            this.store.getChannelById,
+            this.store.getConsensusChannel,
+          );
+
+          return await this.attemptProgress(vdfo);
+        } catch (err) {
+          throw new Error(`handleAPIEvent: Could not create objective for ${virtualDefundOR}: ${err}`);
+        }
+      }
+
       case or instanceof DirectFundObjectiveRequest:
         try {
           const dfo = DirectFundObjective.newObjective(

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -96,12 +96,14 @@ export class VoucherManager {
 
   // ChannelRegistered returns  whether a channel has been registered with the voucher manager or not
   channelRegistered(channelId: Destination): boolean {
+    // TODO: Implement
     return false;
   }
 
   // Paid returns the total amount paid so far on a channel
   // TODO: Can throw an error
   paid(chanId: Destination): bigint {
+    // TODO: Implement
     return BigInt(0);
   }
 

--- a/packages/nitro-client/src/protocols/messages.ts
+++ b/packages/nitro-client/src/protocols/messages.ts
@@ -83,8 +83,17 @@ export class Message {
 
   // CreateVoucherMessage returns a signed voucher message for each of the recipients provided.
   static createVoucherMessage(voucher: Voucher, ...recipients: Address[]): Message[] {
-    // TODO: Implement
-    return [];
+    const messages: Message[] = [];
+    for (const recipient of recipients) {
+      messages.push(
+        new Message({
+          to: recipient,
+          payments: [voucher],
+        }),
+      );
+    }
+
+    return messages;
   }
 
   // Serialize serializes the message into a string.

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -1,9 +1,125 @@
 import { ReadWriteChannel } from '@nodeguy/channel';
 
+import { Destination } from '../../types/destination';
+import { Address } from '../../types/types';
+import { Channel } from '../../channel/channel';
+import { ConsensusChannel } from '../../channel/consensus-channel/consensus-channel';
+import {
+  ObjectiveRequest as ObjectiveRequestInterface,
+  Objective as ObjectiveInterface,
+  SideEffects,
+  WaitingFor,
+  Storable,
+  ObjectiveStatus,
+} from '../interfaces';
+import { ObjectiveId, ObjectivePayload } from '../messages';
+
+// GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
+type GetChannelByIdFunction = (id: Destination) => [ Channel | undefined, boolean ];
+
+// GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between
+// the calling client and the given counterparty, if such a channel exists.
+type GetTwoPartyConsensusLedgerFunction = (counterparty: Address) => [ ConsensusChannel | undefined, boolean ];
+
+export class Objective implements ObjectiveInterface {
+  // NewObjective constructs a new virtual defund objective
+  static newObjective(
+    request: ObjectiveRequest,
+    preApprove: boolean,
+    myAddress: Address,
+    largestPaymentAmount: bigint,
+    getChannel: GetChannelByIdFunction,
+    getConsensusChannel: GetTwoPartyConsensusLedgerFunction,
+  ): Objective {
+    return new Objective();
+  }
+
+  // TODO: Implement
+  id(): ObjectiveId {
+    return '';
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  approve(): Objective {
+    return new Objective();
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  reject(): [Objective, SideEffects] {
+    return [
+      new Objective(),
+      {
+        messagesToSend: [],
+        proposalsToProcess: [],
+        transactionsToSubmit: [],
+      },
+    ];
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  // TODO: Can throw an error
+  update(payload: ObjectivePayload): Objective {
+    return new Objective();
+  }
+
+  // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+  // TODO: Implement
+  // TODO: Can throw an error
+  crank(secretKey: Buffer): [Objective, SideEffects, WaitingFor] {
+    return [
+      new Objective(),
+      {
+        messagesToSend: [],
+        proposalsToProcess: [],
+        transactionsToSubmit: [],
+      },
+      '',
+    ];
+  }
+
+  // Related returns a slice of related objects that need to be stored along with the objective
+  // TODO: Implement
+  related(): Storable[] {
+    return [];
+  }
+
+  // OwnsChannel returns the channel the objective exclusively owns.
+  // TODO: Implement
+  ownsChannel(): Destination {
+    return new Destination();
+  }
+
+  // GetStatus returns the status of the objective.
+  // TODO: Implement
+  getStatus(): ObjectiveStatus {
+    return ObjectiveStatus.Unapproved;
+  }
+}
+
 // ObjectiveRequest represents a request to create a new virtual defund objective.
 // TODO: Implement
-export class ObjectiveRequest {
-  channelId?: string;
+export class ObjectiveRequest implements ObjectiveRequestInterface {
+  channelId: Destination = new Destination();
 
   private objectiveStarted?: ReadWriteChannel<void>;
+
+  // NewObjectiveRequest creates a new ObjectiveRequest.
+  static newObjectiveRequest(channelId: Destination): ObjectiveRequest {
+    // TODO: Implement
+    return new ObjectiveRequest();
+  }
+
+  // TODO: Implement
+  id(address: Address, chainId: bigint): ObjectiveId {
+    return '';
+  }
+
+  // TODO: Implement
+  waitForObjectiveToStart(): void {}
+
+  // TODO: Implement
+  signalObjectiveStarted(): void {}
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port `createVoucherMessage` method required in `pay` command
- Add placeholder methods for `virtual-defund` command
- Port handling of `VirtualDefundObjectiveRequest`