### PR TITLE
Port implementation for `closeVirtualChannel` method in virtual-defund command

### DIFF
--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -27,6 +27,10 @@ import {
   ObjectiveResponse as VirtualFundObjectiveResponse,
   ObjectiveRequest as VirtualFundObjectiveRequest,
 } from '../protocols/virtualfund/virtualfund';
+import {
+  Objective as VirtualDefundObjective,
+  ObjectiveRequest as VirtualDefundObjectiveRequest,
+} from '../protocols/virtualdefund/virtualdefund';
 import { Destination } from '../types/destination';
 import { PaymentChannelInfo } from './query/types';
 import { getPaymentChannelInfo } from './query/query';
@@ -152,8 +156,13 @@ export class Client {
 
   // CloseVirtualChannel attempts to close and defund the given virtually funded channel.
   closeVirtualChannel(channelId: Destination): ObjectiveId {
-    // TODO: Implement
-    return '';
+    const objectiveRequest = VirtualDefundObjectiveRequest.newObjectiveRequest(channelId);
+
+    // Send the event to the engine
+    assert(this.engine.objectiveRequestsFromAPI);
+    this.engine.objectiveRequestsFromAPI.push(objectiveRequest);
+    objectiveRequest.waitForObjectiveToStart();
+    return objectiveRequest.id(this.address, this.chainId);
   }
 
   // Pay will send a signed voucher to the payee that they can redeem for the given amount.

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -36,7 +36,7 @@ const waitingForNothing: WaitingFor = 'WaitingForNothing'; // Finished
 
 const signedStatePayload: PayloadType = 'SignedStatePayload';
 
-const objectivePrefix = 'DirectDefunding-';
+const objectivePrefix = 'DirectFunding-';
 
 // GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 interface GetChannelsByParticipantFunction {

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -1,8 +1,8 @@
-import { ReadWriteChannel } from '@nodeguy/channel';
+import Channel, { ReadWriteChannel } from '@nodeguy/channel';
 
 import { Destination } from '../../types/destination';
 import { Address } from '../../types/types';
-import { Channel } from '../../channel/channel';
+import * as channel from '../../channel/channel';
 import { ConsensusChannel } from '../../channel/consensus-channel/consensus-channel';
 import {
   ObjectiveRequest as ObjectiveRequestInterface,
@@ -15,7 +15,7 @@ import {
 import { ObjectiveId, ObjectivePayload } from '../messages';
 
 // GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
-type GetChannelByIdFunction = (id: Destination) => [ Channel | undefined, boolean ];
+type GetChannelByIdFunction = (id: Destination) => [ channel.Channel | undefined, boolean ];
 
 // GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between
 // the calling client and the given counterparty, if such a channel exists.
@@ -106,14 +106,23 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
 
   private objectiveStarted?: ReadWriteChannel<void>;
 
+  constructor(params: {
+    channelId?: Destination;
+    objectiveStarted?: ReadWriteChannel<void>;
+  }) {
+    Object.assign(this, params);
+  }
+
   // NewObjectiveRequest creates a new ObjectiveRequest.
   static newObjectiveRequest(channelId: Destination): ObjectiveRequest {
-    // TODO: Implement
-    return new ObjectiveRequest();
+    return new ObjectiveRequest({
+      channelId,
+      objectiveStarted: Channel(), // Initialize as an unresolved promise
+    });
   }
 
   // TODO: Implement
-  id(address: Address, chainId: bigint): ObjectiveId {
+  id(address: Address, chainId?: bigint): ObjectiveId {
     return '';
   }
 

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -16,6 +16,8 @@ import {
 } from '../interfaces';
 import { ObjectiveId, ObjectivePayload } from '../messages';
 
+const objectivePrefix = 'VirtualDefund-';
+
 // GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 type GetChannelByIdFunction = (id: Destination) => [ channel.Channel | undefined, boolean ];
 
@@ -123,17 +125,17 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
     });
   }
 
-  // TODO: Implement
   id(address: Address, chainId?: bigint): ObjectiveId {
-    return '';
+    return objectivePrefix + this.channelId.string();
   }
 
-  // TODO: Implement
   async waitForObjectiveToStart(): Promise<void> {
     assert(this.objectiveStarted);
     await this.objectiveStarted.shift();
   }
 
-  // TODO: Implement
-  signalObjectiveStarted(): void {}
+  signalObjectiveStarted(): void {
+    assert(this.objectiveStarted);
+    this.objectiveStarted.close();
+  }
 }

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import Channel, { ReadWriteChannel } from '@nodeguy/channel';
 
 import { Destination } from '../../types/destination';
@@ -127,7 +129,10 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
   }
 
   // TODO: Implement
-  waitForObjectiveToStart(): void {}
+  async waitForObjectiveToStart(): Promise<void> {
+    assert(this.objectiveStarted);
+    await this.objectiveStarted.shift();
+  }
 
   // TODO: Implement
   signalObjectiveStarted(): void {}

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import Channel from '@nodeguy/channel';
 import type { ReadWriteChannel } from '@nodeguy/channel';
 
@@ -376,8 +378,10 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
     return '';
   }
 
-  waitForObjectiveToStart(): void {
-    // TODO: Implement
+  // WaitForObjectiveToStart blocks until the objective starts
+  async waitForObjectiveToStart(): Promise<void> {
+    assert(this.objectiveStarted);
+    await this.objectiveStarted.shift();
   }
 
   signalObjectiveStarted(): void {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementation for `virtualdefund.NewObjectiveRequest` method
- Port implementation for `waitForObjectiveToStart` method
- Port implementation for `ObjectiveRequest.id` method