### PR TITLE
Port method implementations called in direct defund `Client.closeLedgerChannel` method

### DIFF
--- a/packages/nitro-client/src/channel/channel.ts
+++ b/packages/nitro-client/src/channel/channel.ts
@@ -213,8 +213,8 @@ export class Channel extends FixedPart {
 
   // AddSignedState adds a signed state to the Channel, updating the LatestSupportedState and Support if appropriate.
   // Returns false and does not alter the channel if the state is "stale", belongs to a different channel, or is signed by a non participant.
-  // TODO: Implement
   addSignedState(ss: SignedState): boolean {
+    // TODO: Implement
     return false;
   }
 

--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -140,7 +140,6 @@ export class Client {
     this.engine.objectiveRequestsFromAPI.push(objectiveRequest);
     objectiveRequest.waitForObjectiveToStart();
     return objectiveRequest.id(this.address, this.chainId);
-    return '';
   }
 
   // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels

--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -24,6 +24,10 @@ import {
   ObjectiveRequest as DirectFundObjectiveRequest,
 } from '../protocols/directfund/directfund';
 import {
+  Objective as DirectDefundObjective,
+  ObjectiveRequest as DirectDefundObjectiveRequest,
+} from '../protocols/directdefund/directdefund';
+import {
   ObjectiveResponse as VirtualFundObjectiveResponse,
   ObjectiveRequest as VirtualFundObjectiveRequest,
 } from '../protocols/virtualfund/virtualfund';
@@ -129,7 +133,13 @@ export class Client {
 
   // CloseLedgerChannel attempts to close and defund the given directly funded channel.
   closeLedgerChannel(channelId: Destination): ObjectiveId {
-    // TODO: Implement
+    const objectiveRequest = DirectDefundObjectiveRequest.newObjectiveRequest(channelId);
+
+    assert(this.engine.objectiveRequestsFromAPI);
+    // Send the event to the engine
+    this.engine.objectiveRequestsFromAPI.push(objectiveRequest);
+    objectiveRequest.waitForObjectiveToStart();
+    return objectiveRequest.id(this.address, this.chainId);
     return '';
   }
 

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -1,15 +1,18 @@
-import { ReadWriteChannel } from '@nodeguy/channel';
+import Channel, { ReadWriteChannel } from '@nodeguy/channel';
 
 import { Destination } from '../../types/destination';
 import { ConsensusChannel } from '../../channel/consensus-channel/consensus-channel';
-import { Channel } from '../../channel/channel';
+import * as channel from '../../channel/channel';
+import { ObjectiveRequest as ObjectiveRequestInterface } from '../interfaces';
+import { ObjectiveId } from '../messages';
+import { Address } from '../../types/types';
 
 // GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.
 type GetConsensusChannel = (channelId: Destination) => [ConsensusChannel | undefined, Error];
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
 // TODO: Implement
-const isInConsensusOrFinalState = (c: Channel): boolean => false;
+const isInConsensusOrFinalState = (c: channel.Channel): boolean => false;
 
 export class Objective {
   // NewObjective initiates an Objective with the supplied channel
@@ -25,17 +28,35 @@ export class Objective {
 
 // createChannelFromConsensusChannel creates a Channel with (an appropriate latest supported state) from the supplied ConsensusChannel.
 // TODO: Implement
-const createChannelFromConsensusChannel = (cc: ConsensusChannel): Channel => new Channel({});
+const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channel => new channel.Channel({});
 
 // ObjectiveRequest represents a request to create a new direct defund objective.
 // TODO: Implement
-export class ObjectiveRequest {
-  channelId?: string;
+export class ObjectiveRequest implements ObjectiveRequestInterface {
+  channelId?: Destination;
 
   private objectiveStarted?: ReadWriteChannel<void>;
 
+  constructor(params: {
+    channelId?: Destination,
+    objectiveStarted: ReadWriteChannel<void>
+  }) {
+    Object.assign(this, params);
+  }
+
   // NewObjectiveRequest creates a new ObjectiveRequest.
   static newObjectiveRequest(channelId: Destination): ObjectiveRequest {
-    return new ObjectiveRequest();
+    return new ObjectiveRequest({
+      channelId,
+      objectiveStarted: Channel(),
+    });
   }
+
+  id(address: Address, chainId?: bigint): ObjectiveId {
+    return '';
+  }
+
+  waitForObjectiveToStart(): void {}
+
+  signalObjectiveStarted(): void {}
 }

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -1,11 +1,14 @@
 import Channel, { ReadWriteChannel } from '@nodeguy/channel';
 
+import assert from 'assert';
 import { Destination } from '../../types/destination';
 import { ConsensusChannel } from '../../channel/consensus-channel/consensus-channel';
 import * as channel from '../../channel/channel';
 import { ObjectiveRequest as ObjectiveRequestInterface } from '../interfaces';
 import { ObjectiveId } from '../messages';
 import { Address } from '../../types/types';
+
+const ObjectivePrefix = 'DirectDefunding-';
 
 // GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.
 type GetConsensusChannel = (channelId: Destination) => [ConsensusChannel | undefined, Error];
@@ -33,7 +36,7 @@ const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channe
 // ObjectiveRequest represents a request to create a new direct defund objective.
 // TODO: Implement
 export class ObjectiveRequest implements ObjectiveRequestInterface {
-  channelId?: Destination;
+  channelId: Destination = new Destination();
 
   private objectiveStarted?: ReadWriteChannel<void>;
 
@@ -53,10 +56,13 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
   }
 
   id(address: Address, chainId?: bigint): ObjectiveId {
-    return '';
+    return ObjectivePrefix + this.channelId.string();
   }
 
-  waitForObjectiveToStart(): void {}
+  async waitForObjectiveToStart(): Promise<void> {
+    assert(this.objectiveStarted);
+    await this.objectiveStarted.shift();
+  }
 
   signalObjectiveStarted(): void {}
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementation for `client.closeLedgerChannel` method
- Port implementation for `newObjectiveRequest` method
- Port implementation for `ObjectiveRequest` methods
  - `id`
  - `waitForObjectiveToStart`