### PR TITLE
Port implementation for handling `DirectDefundObjectiveRequest`

### DIFF
--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -284,27 +284,27 @@ export class Engine {
     let deferredSignalObjectiveStarted;
 
     try {
-    assert(this.store);
-    assert(this.chain);
-    assert(this.logger);
+      assert(this.store);
+      assert(this.chain);
+      assert(this.logger);
 
-    // TODO: Implement metrics
-    // defer e.metrics.RecordFunctionDuration()()
+      // TODO: Implement metrics
+      // defer e.metrics.RecordFunctionDuration()()
 
-    const myAddress = this.store.getAddress();
+      const myAddress = this.store.getAddress();
 
-    let chainId: bigint;
-    try {
-      chainId = await this.chain.getChainId();
-    } catch (err) {
-      throw new Error(`could get chain id from chain service: ${err}`);
-    }
+      let chainId: bigint;
+      try {
+        chainId = await this.chain.getChainId();
+      } catch (err) {
+        throw new Error(`could get chain id from chain service: ${err}`);
+      }
 
-    const objectiveId = or.id(myAddress, chainId);
-    this.logger(`handling new objective request for ${objectiveId}`);
+      const objectiveId = or.id(myAddress, chainId);
+      this.logger(`handling new objective request for ${objectiveId}`);
 
-    // TODO: Implement metrics
-    // e.metrics.RecordObjectiveStarted(objectiveId);
+      // TODO: Implement metrics
+      // e.metrics.RecordObjectiveStarted(objectiveId);
 
       deferredSignalObjectiveStarted = () => or.signalObjectiveStarted();
 

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -281,6 +281,9 @@ export class Engine {
   // It will attempt to spawn a new, approved objective.
   // TODO: Can throw an error
   private async handleObjectiveRequest(or: ObjectiveRequest): Promise<EngineEvent> {
+    let deferredSignalObjectiveStarted;
+
+    try {
     assert(this.store);
     assert(this.chain);
     assert(this.logger);
@@ -303,7 +306,8 @@ export class Engine {
     // TODO: Implement metrics
     // e.metrics.RecordObjectiveStarted(objectiveId);
 
-    try {
+      deferredSignalObjectiveStarted = () => or.signalObjectiveStarted();
+
       switch (true) {
         case or instanceof VirtualFundObjectiveRequest: {
           let vfo: VirtualFundObjective;
@@ -396,7 +400,9 @@ export class Engine {
           throw new Error(`handleAPIEvent: Unknown objective type ${typeof or}`);
       }
     } finally {
-      or.signalObjectiveStarted();
+      if (deferredSignalObjectiveStarted) {
+        deferredSignalObjectiveStarted();
+      }
     }
   }
 

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -386,7 +386,6 @@ export class Engine {
           const request = or as DirectDefundObjectiveRequest;
           let ddfo: DirectDefundObjective;
           try {
-            // TODO: Implement
             ddfo = DirectDefundObjective.newObjective(request, true, this.store.getConsensusChannelById);
           } catch (err) {
             throw new Error(`handleAPIEvent: Could not create objective for ${JSON.stringify(request)}: ${err}`);

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -197,7 +197,7 @@ export class MemStore implements Store {
   }
 
   // TODO: Implement
-  getConsensusChannelById(id: string): ConsensusChannel {
+  getConsensusChannelById(id: Destination): ConsensusChannel {
     return {} as ConsensusChannel;
   }
 

--- a/packages/nitro-client/src/client/engine/store/store.ts
+++ b/packages/nitro-client/src/client/engine/store/store.ts
@@ -63,7 +63,7 @@ export interface ConsensusChannelStore {
   getConsensusChannel (counterparty: Address): [ConsensusChannel | undefined, boolean]
 
   // TODO: Can throw an error
-  getConsensusChannelById (id: string): ConsensusChannel
+  getConsensusChannelById (id: Destination): ConsensusChannel | undefined
 
   // TODO: Can throw an error
   setConsensusChannel (ch: ConsensusChannel): void

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -4,20 +4,22 @@ import assert from 'assert';
 import { Destination } from '../../types/destination';
 import { ConsensusChannel } from '../../channel/consensus-channel/consensus-channel';
 import * as channel from '../../channel/channel';
-import { ObjectiveRequest as ObjectiveRequestInterface } from '../interfaces';
-import { ObjectiveId } from '../messages';
+import {
+  ObjectiveRequest as ObjectiveRequestInterface, Objective as ObjectiveInterface, SideEffects, WaitingFor, Storable, ObjectiveStatus,
+} from '../interfaces';
+import { ObjectiveId, ObjectivePayload } from '../messages';
 import { Address } from '../../types/types';
 
 const ObjectivePrefix = 'DirectDefunding-';
 
 // GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.
-type GetConsensusChannel = (channelId: Destination) => [ConsensusChannel | undefined, Error];
+type GetConsensusChannel = (channelId: Destination) => ConsensusChannel | undefined;
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
 // TODO: Implement
 const isInConsensusOrFinalState = (c: channel.Channel): boolean => false;
 
-export class Objective {
+export class Objective implements ObjectiveInterface {
   // NewObjective initiates an Objective with the supplied channel
   static newObjective(
     request: ObjectiveRequest,
@@ -26,6 +28,68 @@ export class Objective {
   ): Objective {
     // TODO: Implement
     return new Objective();
+  }
+
+  // TODO: Implement
+  id(): ObjectiveId {
+    return '';
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  approve(): Objective {
+    return new Objective();
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  reject(): [Objective, SideEffects] {
+    return [
+      new Objective(),
+      {
+        messagesToSend: [],
+        proposalsToProcess: [],
+        transactionsToSubmit: [],
+      },
+    ];
+  }
+
+  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+  // TODO: Implement
+  update(payload: ObjectivePayload): Objective {
+    return new Objective();
+  }
+
+  // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+  // TODO: Implement
+  crank(secretKey: Buffer): [Objective, SideEffects, WaitingFor] {
+    return [
+      new Objective(),
+      {
+        messagesToSend: [],
+        proposalsToProcess: [],
+        transactionsToSubmit: [],
+      },
+      '',
+    ];
+  }
+
+  // Related returns a slice of related objects that need to be stored along with the objective
+  // TODO: Implement
+  related(): Storable[] {
+    return [];
+  }
+
+  // OwnsChannel returns the channel the objective exclusively owns.
+  // TODO: Implement
+  ownsChannel(): Destination {
+    return new Destination();
+  }
+
+  // GetStatus returns the status of the objective.
+  // TODO: Implement
+  getStatus(): ObjectiveStatus {
+    return ObjectiveStatus.Unapproved;
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementations of `handleObjectiveRequest` method for direct defund
- Implement Go defer behaviour using try / finally
- Port implementations of `newObjective` method for direct defund