### PR TITLE
Port implementation for `getConsensusChannel` and `fundingTargets` methods in direct-defund

### DIFF
--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -192,8 +192,13 @@ export class LedgerOutcome {
 
   // FundingTargets returns a list of channels funded by the LedgerOutcome
   fundingTargets(): Destination[] {
-    // TODO: Implement
-    return [];
+    const targets: Destination[] = [];
+
+    for (const [dest] of this.guarantees!) {
+      targets.push(dest);
+    }
+
+    return targets;
   }
 }
 
@@ -262,7 +267,7 @@ export class ConsensusChannel {
 
   onChainFunding?: Funds;
 
-  private fp?: FixedPart;
+  private fp: FixedPart = new FixedPart({});
 
   // variables
 
@@ -500,9 +505,8 @@ export class ConsensusChannel {
   private validateProposalID(propsal: Proposal): void {}
 
   // Participants returns the channel participants.
-  // TODO: Implement
   participants(): Address[] {
-    return [];
+    return this.fp.participants;
   }
 
   // Clone returns a deep copy of the receiver.
@@ -515,6 +519,18 @@ export class ConsensusChannel {
   supportedSignedState(): SignedState {
     // TODO: Implement
     return {} as SignedState;
+  }
+
+  // UnmarshalJSON populates the receiver with the
+  // json-encoded data
+  unmarshalJSON(data: Buffer) {
+    try {
+      // TODO: Implement json.Unmarshal
+      const jsonCh = JSON.parse(data.toString());
+      Object.assign(this, jsonCh);
+    } catch (err) {
+      throw new Error(`error unmarshaling channel data: ${err}`);
+    }
   }
 }
 

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -196,9 +196,23 @@ export class MemStore implements Store {
     return [];
   }
 
-  // TODO: Implement
+  // GetConsensusChannelById returns a ConsensusChannel with the given channel id
   getConsensusChannelById(id: Destination): ConsensusChannel {
-    return {} as ConsensusChannel;
+    const [chJSON, ok] = this.consensusChannels.load(id.string());
+
+    if (!ok) {
+      throw ErrNoSuchChannel;
+    }
+    assert(chJSON);
+
+    const ch = new ConsensusChannel({});
+    try {
+      ch.unmarshalJSON(chJSON);
+    } catch (err) {
+      throw new Error(`error unmarshaling channel ${ch.id}`);
+    }
+
+    return ch;
   }
 
   // getConsensusChannel returns a ConsensusChannel between the calling client and

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -45,7 +45,6 @@ export class Objective implements ObjectiveInterface {
     let cc: ConsensusChannel;
 
     try {
-      // TODO: Implement MemStore.getConsensusChannelById
       cc = getConsensusChannel(request.channelId) as ConsensusChannel;
     } catch (err) {
       throw new Error(`could not find channel ${request.channelId}; ${err}`);


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementation for `MemStore.getConsensusChannelById` method
- Port implementation for `ledgerOutcome.fundingTargets` method