### PR TITLE
Port implementation for `createChannelFromConsensusChannel` method in direct-defund

### DIFF
--- a/packages/nitro-client/src/channel/channel.ts
+++ b/packages/nitro-client/src/channel/channel.ts
@@ -32,7 +32,7 @@ export class Channel extends FixedPart {
   // It could be an array of turnNums, which can be used to slice into Channel.SignedStateForTurnNum
 
   // TODO: unit64 replacement
-  signedStateForTurnNum?: Map<number, SignedState>;
+  signedStateForTurnNum: Map<number, SignedState> = new Map();
   // Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 
   // largest uint64 value reserved for "no supported state"

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -517,8 +517,13 @@ export class ConsensusChannel {
 
   // SupportedSignedState returns the latest supported signed state.
   supportedSignedState(): SignedState {
-    // TODO: Implement
-    return {} as SignedState;
+    const s = this.consensusVars().asState(this.fp);
+    const sigs = this.current.signatures;
+    const ss: SignedState = SignedState.newSignedState(s);
+    ss.addSignature(sigs[0]);
+    ss.addSignature(sigs[1]);
+
+    return ss;
   }
 
   // UnmarshalJSON populates the receiver with the

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -94,7 +94,7 @@ export class LedgerOutcome {
   // Balance of participants[1]
   private follower?: Balance;
 
-  private guarantees?: Map<Destination, Guarantee>;
+  private guarantees: Map<Destination, Guarantee> = new Map();
 
   constructor(params: {
     assetAddress?: Address;
@@ -265,7 +265,7 @@ export class ConsensusChannel {
 
   myIndex: LedgerIndex = 0;
 
-  onChainFunding?: Funds;
+  onChainFunding: Funds = new Funds();
 
   private fp: FixedPart = new FixedPart({});
 

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -299,10 +299,7 @@ export class ConsensusChannel {
     outcome: LedgerOutcome,
     signatures: [Signature, Signature],
   ): ConsensusChannel {
-    const error = fp.validate();
-    if (error) {
-      throw error;
-    }
+    fp.validate();
 
     const cId = fp.channelId();
 

--- a/packages/nitro-client/src/channel/state/outcome/exit.ts
+++ b/packages/nitro-client/src/channel/state/outcome/exit.ts
@@ -73,6 +73,17 @@ export class Exit {
     this.value = value;
   }
 
+  // Clone returns a deep clone of the receiver.
+  clone(): Exit {
+    const clone = new Exit([]);
+
+    for (const [i, sae] of this.value.entries()) {
+      clone.value[i] = sae.clone();
+    }
+
+    return clone;
+  }
+
   // totalAllocated returns the sum of all Funds that are allocated by the outcome.
   //
   // NOTE that these Funds are potentially different from a channel's capacity to
@@ -81,6 +92,7 @@ export class Exit {
     const fullValue = new Funds();
 
     for (const assetExit of this.value) {
+      // TODO: Implement
       fullValue.value.set(assetExit.asset, assetExit.totalAllocated());
     }
 

--- a/packages/nitro-client/src/channel/state/signedstate.ts
+++ b/packages/nitro-client/src/channel/state/signedstate.ts
@@ -36,6 +36,7 @@ export class SignedState {
   addSignature(sig: Signature): void {
     let signer: Address;
     try {
+      // TODO: Implement
       signer = this.state().recoverSigner(sig);
     } catch (err) {
       throw new Error('AddSignature failed to recover signer');
@@ -80,8 +81,11 @@ export class SignedState {
   }
 
   // HasAllSignatures returns true if every participant has a valid signature.
-  // TODO: Implement
   hasAllSignatures(): boolean {
+    // Since signatures are validated
+    if (this.sigs.size === this.state().participants.length) {
+      return true;
+    }
     return false;
   }
 

--- a/packages/nitro-client/src/channel/state/signedstate.ts
+++ b/packages/nitro-client/src/channel/state/signedstate.ts
@@ -10,7 +10,7 @@ export class SignedState {
   private _state?: State;
 
   // TODO: uint replacement
-  private sigs?: Map<number, Signature>; // keyed by participant index
+  private sigs: Map<number, Signature> = new Map(); // keyed by participant index
 
   constructor(params: {
     state?: State,

--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -44,14 +44,10 @@ export class FixedPart {
   }
 
   // Validate checks whether the receiver is malformed and returns an error if it is.
-  // TODO: Can throw an error
-  // TODO: Implement
-  validate(): Error | null {
+  validate(): void {
     if (this.channelId().isExternal()) {
-      return new Error('channelId is an external destination'); // This is extremely unlikely
+      throw new Error('channelId is an external destination'); // This is extremely unlikely
     }
-
-    return null;
   }
 }
 
@@ -150,10 +146,9 @@ export class State {
   }
 
   // RecoverSigner computes the Ethereum address which generated Signature sig on State state
-  // TODO: Can throw an error
   recoverSigner(sig: Signature): Address {
-    // TODO: Implement
-    return ethers.constants.AddressZero;
+    const stateHash = this.hash();
+    return nc.recoverEthereumMessageSigner(Buffer.from(stateHash), sig);
   }
 
   // Equal returns true if the given State is deeply equal to the receiever.
@@ -163,14 +158,31 @@ export class State {
   }
 
   // Validate checks whether the state is malformed and returns an error if it is.
-  // TODO: Can throw an error
-  // TODO: Implement
-  validate(): void {}
+  validate(): void {
+    return this.fixedPart().validate();
+  }
 
   // Clone returns a deep copy of the receiver.
-  // TODO: Implement
   clone(): State {
-    return {} as State;
+    const clone = new State({});
+
+    // Fixed part
+    const cloneFixedPart = this.fixedPart().clone();
+    clone.participants = cloneFixedPart.participants;
+    clone.channelNonce = cloneFixedPart.channelNonce;
+    clone.appDefinition = cloneFixedPart.appDefinition;
+    clone.challengeDuration = cloneFixedPart.challengeDuration;
+
+    // Variable part
+    if (this.appData) {
+      clone.appData = Buffer.alloc(this.appData.length);
+      clone.appData = Buffer.from(this.appData);
+    }
+    clone.outcome = this.outcome.clone();
+    clone.turnNum = this.turnNum;
+    clone.isFinal = this.isFinal;
+
+    return clone;
   }
 }
 

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -30,7 +30,7 @@ const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channe
     Number(cc.myIndex),
   );
 
-  c.onChainFunding = cc.onChainFunding!.clone();
+  c.onChainFunding = cc.onChainFunding.clone();
   // TODO: Implement methods
   c.addSignedState(cc.supportedSignedState());
 

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -31,7 +31,6 @@ const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channe
   );
 
   c.onChainFunding = cc.onChainFunding.clone();
-  // TODO: Implement methods
   c.addSignedState(cc.supportedSignedState());
 
   return c;

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -24,8 +24,18 @@ type GetConsensusChannel = (channelId: Destination) => ConsensusChannel | undefi
 const isInConsensusOrFinalState = (c: channel.Channel): boolean => false;
 
 // createChannelFromConsensusChannel creates a Channel with (an appropriate latest supported state) from the supplied ConsensusChannel.
-// TODO: Implement
-const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channel => new channel.Channel({});
+const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channel => {
+  const c = channel.Channel.new(
+    cc.consensusVars().asState(cc.supportedSignedState().state().fixedPart()),
+    Number(cc.myIndex),
+  );
+
+  c.onChainFunding = cc.onChainFunding!.clone();
+  // TODO: Implement methods
+  c.addSignedState(cc.supportedSignedState());
+
+  return c;
+};
 
 export class Objective implements ObjectiveInterface {
   status: ObjectiveStatus = ObjectiveStatus.Unapproved;
@@ -54,12 +64,12 @@ export class Objective implements ObjectiveInterface {
       throw ErrNotEmpty;
     }
 
-    // TODO: Implement
     const c = createChannelFromConsensusChannel(cc);
 
     // We choose to disallow creating an objective if the channel has an in-progress update.
     // We allow the creation of of an objective if the channel has some final states.
     // In the future, we can add a restriction that only defund objectives can add final states to the channel.
+    // TODO: Implement
     const canCreateObjective = isInConsensusOrFinalState(c);
 
     if (!canCreateObjective) {

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -160,10 +160,8 @@ export class Objective implements ObjectiveInterface {
 
     const initialState = initialSignedState.state();
     assert(initialState);
-    const error = initialState.fixedPart().validate();
-    if (error) {
-      throw error;
-    }
+    initialState.fixedPart().validate();
+
     if (initialState.turnNum !== 0) {
       throw new Error('cannot construct direct fund objective without prefund state');
     }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementation for direct-defund `createChannelFromConsensusChannel` method
- Port implementation for `ConsensusChannel.supportedSignedState` method
- Port implementation for `SignedState.addSignature` method
- Port implementation for `Channel.addSignedState` method
- Set new empty map as zero value for map types in TypeScript