### PR TITLE
Port implementation for `isInConsensusOrFinalState` method in direct-defund

### DIFF
--- a/packages/nitro-client/package.json
+++ b/packages/nitro-client/package.json
@@ -19,6 +19,7 @@
     "@types/chai": "^4.3.5",
     "@types/debug": "^4.1.7",
     "@types/json-bigint": "^1.0.1",
+    "@types/lodash": "^4.14.195",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.2.1",
     "@types/webpack": "^5.28.1",
@@ -53,6 +54,7 @@
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
     "json-bigint": "^1.0.0",
-    "libp2p": "^0.45.3"
+    "libp2p": "^0.45.3",
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/nitro-client/src/channel/channel.ts
+++ b/packages/nitro-client/src/channel/channel.ts
@@ -203,10 +203,17 @@ export class Channel extends FixedPart {
   }
 
   // LatestSignedState fetches the state with the largest turn number signed by at least one participant.
-  // TODO: Can throw an error
   latestSignedState(): SignedState {
-    // TODO: Implement
-    return {} as SignedState;
+    if (this.signedStateForTurnNum.size === 0) {
+      throw new Error('no states are signed');
+    }
+    let latestTurn = 0;
+    for (const [k] of this.signedStateForTurnNum) {
+      if (k > latestTurn) {
+        latestTurn = k;
+      }
+    }
+    return this.signedStateForTurnNum.get(latestTurn)!;
   }
 
   // Total() returns the total allocated of each asset allocated by the pre fund setup state of the Channel.

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -27,7 +27,6 @@ const isInConsensusOrFinalState = (c: channel.Channel): boolean => {
   let latestSS = new SignedState({});
 
   try {
-    // TODO: Implement
     latestSS = c.latestSignedState();
   } catch (err) {
     // There are no signed states. We consider this as consensus

--- a/yarn.lock
+++ b/yarn.lock
@@ -3840,6 +3840,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.195":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+
 "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Port implementation for direct-defund `isInConsensusOrFinalState` method
- Port implementation for `latestSignedState` method