### PR TITLE
Port remaining methods in `directdefund` and `exit` files

### DIFF
--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -327,7 +327,15 @@ function equalParticipants(p: Address[], q: Address[]): boolean {
 }
 
 // StateFromFixedAndVariablePart constructs a State from a FixedPart and a VariablePart
-// TODO: Implement
 export function stateFromFixedAndVariablePart(f: FixedPart, v: VariablePart): State {
-  return {} as State;
+  return new State({
+    participants: f.participants,
+    channelNonce: f.channelNonce,
+    appDefinition: f.appDefinition,
+    challengeDuration: f.challengeDuration,
+    appData: v.appData,
+    outcome: v.outcome,
+    turnNum: v.turnNum,
+    isFinal: v.isFinal,
+  });
 }

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -38,6 +38,10 @@ const SignedStatePayload: PayloadType = 'SignedStatePayload';
 
 const ObjectivePrefix = 'DirectFunding-';
 
+export function fundOnChainEffect(cId: Destination, asset: string, amount: Funds): string {
+  return `deposit ${amount} into ${cId}`;
+}
+
 // GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 interface GetChannelsByParticipantFunction {
   (participant: Address): channel.Channel[];

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -892,9 +892,9 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
     await this.objectiveStarted.shift();
   }
 
-  async signalObjectiveStarted(): Promise<void> {
+  signalObjectiveStarted(): void {
     assert(this.objectiveStarted);
-    await this.objectiveStarted.close();
+    this.objectiveStarted.close();
   }
 
   // response computes and returns the appropriate response from the request.


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Implement directdefund `constructObjectiveFromPayload` method
- Implement Exit class methods - `affords` and `toEasyExit`