### PR TITLE
Port remaining methods in `channel-notifier`, `p2p-message-service` and `memstore`

### DIFF
--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -217,8 +217,8 @@ export class MemStore implements Store {
       let ch: Channel;
       try {
         ch = Channel.fromJSON(chJSON.toString());
-      } catch (handleError) {
-        err = handleError as Error;
+      } catch (unmarshalErr) {
+        err = unmarshalErr as Error;
         return false;
       }
 
@@ -252,8 +252,8 @@ export class MemStore implements Store {
 
       try {
         ch = Channel.fromJSON(chJSON.toString());
-      } catch (handleError) {
-        err = handleError as Error;
+      } catch (unmarshalErr) {
+        err = unmarshalErr as Error;
         return false;
       }
 
@@ -350,8 +350,8 @@ export class MemStore implements Store {
 
       try {
         ch = ConsensusChannel.fromJSON(chJSON.toString());
-      } catch (handleError) {
-        err = handleError as Error;
+      } catch (unmarshalErr) {
+        err = unmarshalErr as Error;
         return false;
       }
 

--- a/packages/nitro-client/src/client/notifier/channel-notifier.ts
+++ b/packages/nitro-client/src/client/notifier/channel-notifier.ts
@@ -41,19 +41,19 @@ export class ChannelNotifier {
   // It should be called whenever a ledger channel is updated.
   notifyLedgerUpdated(info: LedgerChannelInfo): void {
     const [li] = this.ledgerListeners!.loadOrStore(info.iD.string(), LedgerChannelListeners.newLedgerChannelListeners());
-    li.Notify(info);
+    li.notify(info);
 
     const [allLi] = this.ledgerListeners!.loadOrStore(ALL_NOTIFICATIONS, LedgerChannelListeners.newLedgerChannelListeners());
-    allLi.Notify(info);
+    allLi.notify(info);
   }
 
   // NotifyPaymentUpdated notifies all listeners of a payment channel update.
   // It should be called whenever a payment channel is updated.
   notifyPaymentUpdated(info: PaymentChannelInfo): void {
     const [li] = this.paymentListeners!.loadOrStore(info.iD.string(), PaymentChannelListeners.newPaymentChannelListeners());
-    li.Notify(info);
+    li.notify(info);
 
     const [allLi] = this.paymentListeners!.loadOrStore(ALL_NOTIFICATIONS, PaymentChannelListeners.newPaymentChannelListeners());
-    allLi.Notify(info);
+    allLi.notify(info);
   }
 }

--- a/packages/nitro-client/src/client/notifier/channel-notifier.ts
+++ b/packages/nitro-client/src/client/notifier/channel-notifier.ts
@@ -2,23 +2,58 @@
 
 import { VoucherManager } from '../../payments/voucher-manager';
 import { Store } from '../engine/store/store';
+import { PaymentChannelListeners, LedgerChannelListeners } from './listeners';
+import { SafeSyncMap } from '../../internal/safesync/safesync';
 import { LedgerChannelInfo, PaymentChannelInfo } from '../query/types';
 
-// TODO: Implement
+const ALL_NOTIFICATIONS = 'all';
+
+// ChannelNotifier is used to notify multiple listeners of a channel update.
 export class ChannelNotifier {
+  private ledgerListeners?: SafeSyncMap<LedgerChannelListeners>;
+
+  private paymentListeners?: SafeSyncMap<PaymentChannelListeners>;
+
+  private store?: Store;
+
+  private vm?: VoucherManager;
+
+  constructor(params: {
+    ledgerListeners: SafeSyncMap<LedgerChannelListeners>;
+    paymentListeners: SafeSyncMap<PaymentChannelListeners>;
+    store: Store;
+    vm: VoucherManager;
+  }) {
+    Object.assign(this, params);
+  }
+
   // NewChannelNotifier constructs a channel notifier using the provided store.
   static newChannelNotifier(store: Store, vm: VoucherManager): ChannelNotifier {
-    // TODO: Implement
-    return new ChannelNotifier();
+    return new ChannelNotifier({
+      ledgerListeners: new SafeSyncMap<LedgerChannelListeners>(),
+      paymentListeners: new SafeSyncMap<PaymentChannelListeners>(),
+      store,
+      vm,
+    });
   }
 
   // NotifyLedgerUpdated notifies all listeners of a ledger channel update.
   // It should be called whenever a ledger channel is updated.
-  // TODO: Implement
-  notifyLedgerUpdated(info: LedgerChannelInfo) {}
+  notifyLedgerUpdated(info: LedgerChannelInfo): void {
+    const [li] = this.ledgerListeners!.loadOrStore(info.iD.string(), LedgerChannelListeners.newLedgerChannelListeners());
+    li.Notify(info);
+
+    const [allLi] = this.ledgerListeners!.loadOrStore(ALL_NOTIFICATIONS, LedgerChannelListeners.newLedgerChannelListeners());
+    allLi.Notify(info);
+  }
 
   // NotifyPaymentUpdated notifies all listeners of a payment channel update.
   // It should be called whenever a payment channel is updated.
-  // TODO: Implement
-  notifyPaymentUpdated(info: PaymentChannelInfo) {}
+  notifyPaymentUpdated(info: PaymentChannelInfo): void {
+    const [li] = this.paymentListeners!.loadOrStore(info.iD.string(), PaymentChannelListeners.newPaymentChannelListeners());
+    li.Notify(info);
+
+    const [allLi] = this.paymentListeners!.loadOrStore(ALL_NOTIFICATIONS, PaymentChannelListeners.newPaymentChannelListeners());
+    allLi.Notify(info);
+  }
 }

--- a/packages/nitro-client/src/client/notifier/listeners.ts
+++ b/packages/nitro-client/src/client/notifier/listeners.ts
@@ -1,0 +1,81 @@
+import Channel, { ReadWriteChannel } from '@nodeguy/channel';
+
+import { LedgerChannelInfo, PaymentChannelInfo } from '../query/types';
+
+// paymentChannelListeners is a struct that holds a list of listeners for payment channel info.
+export class PaymentChannelListeners {
+  // listeners is a list of listeners for payment channel info that we need to notify.
+  listeners?: ReadWriteChannel<PaymentChannelInfo>[];
+
+  // prev is the previous payment channel info that was sent to the listeners.
+  prev?: PaymentChannelInfo;
+
+  // TODO: Implement
+  // listenersLock is used to protect against concurrent access to the listeners slice.
+  // listenersLock *sync.Mutex
+
+  constructor(params: {
+    listeners?: ReadWriteChannel<PaymentChannelInfo>[];
+    prev?: PaymentChannelInfo
+  }) {
+    Object.assign(this, params);
+  }
+
+  // newPaymentChannelListeners constructs a new payment channel listeners struct.
+  static newPaymentChannelListeners(): PaymentChannelListeners {
+    return new PaymentChannelListeners({ listeners: [] });
+  }
+
+  /* eslint-disable no-await-in-loop */
+  // Notify notifies all listeners of a payment channel update.
+  // It only notifies listeners if the new info is different from the previous info.
+  async Notify(info: PaymentChannelInfo): Promise<void> {
+    if (this.prev?.equal(info)) {
+      return;
+    }
+
+    for (const [, list] of this.listeners!.entries()) {
+      await list.push(info);
+    }
+    this.prev = info;
+  }
+}
+
+// ledgerChannelListeners is a struct that holds a list of listeners for ledger channel info.
+export class LedgerChannelListeners {
+  // listeners is a list of listeners for ledger channel info that we need to notify.
+  listeners?: ReadWriteChannel<LedgerChannelInfo>[];
+
+  // prev is the previous ledger channel info that was sent to the listeners.
+  prev?: LedgerChannelInfo;
+
+  // TODO: Implement
+  // listenersLock is used to protect against concurrent access to the listeners slice.
+  // listenersLock sync.Mutex
+
+  constructor(params: {
+    listeners?: ReadWriteChannel<LedgerChannelInfo>[];
+    prev?: LedgerChannelInfo
+  }) {
+    Object.assign(this, params);
+  }
+
+  // newPaymentChannelListeners constructs a new payment channel listeners struct.
+  static newLedgerChannelListeners(): LedgerChannelListeners {
+    return new LedgerChannelListeners({ listeners: [] });
+  }
+
+  /* eslint-disable no-await-in-loop */
+  // Notify notifies all listeners of a ledger channel update.
+  // It only notifies listeners if the new info is different from the previous info.
+  async Notify(info: LedgerChannelInfo): Promise<void> {
+    if (this.prev?.equal(info)) {
+      return;
+    }
+
+    for (const [, list] of this.listeners!.entries()) {
+      await list.push(info);
+    }
+    this.prev = info;
+  }
+}

--- a/packages/nitro-client/src/client/notifier/listeners.ts
+++ b/packages/nitro-client/src/client/notifier/listeners.ts
@@ -5,10 +5,10 @@ import { LedgerChannelInfo, PaymentChannelInfo } from '../query/types';
 // paymentChannelListeners is a struct that holds a list of listeners for payment channel info.
 export class PaymentChannelListeners {
   // listeners is a list of listeners for payment channel info that we need to notify.
-  listeners?: ReadWriteChannel<PaymentChannelInfo>[];
+  listeners: ReadWriteChannel<PaymentChannelInfo>[] = [];
 
   // prev is the previous payment channel info that was sent to the listeners.
-  prev?: PaymentChannelInfo;
+  prev: PaymentChannelInfo = new PaymentChannelInfo({});
 
   // TODO: Implement
   // listenersLock is used to protect against concurrent access to the listeners slice.
@@ -29,7 +29,7 @@ export class PaymentChannelListeners {
   /* eslint-disable no-await-in-loop */
   // Notify notifies all listeners of a payment channel update.
   // It only notifies listeners if the new info is different from the previous info.
-  async Notify(info: PaymentChannelInfo): Promise<void> {
+  async notify(info: PaymentChannelInfo): Promise<void> {
     if (this.prev?.equal(info)) {
       return;
     }
@@ -44,10 +44,10 @@ export class PaymentChannelListeners {
 // ledgerChannelListeners is a struct that holds a list of listeners for ledger channel info.
 export class LedgerChannelListeners {
   // listeners is a list of listeners for ledger channel info that we need to notify.
-  listeners?: ReadWriteChannel<LedgerChannelInfo>[];
+  listeners: ReadWriteChannel<LedgerChannelInfo>[] = [];
 
   // prev is the previous ledger channel info that was sent to the listeners.
-  prev?: LedgerChannelInfo;
+  prev: LedgerChannelInfo = new LedgerChannelInfo({});
 
   // TODO: Implement
   // listenersLock is used to protect against concurrent access to the listeners slice.
@@ -68,7 +68,7 @@ export class LedgerChannelListeners {
   /* eslint-disable no-await-in-loop */
   // Notify notifies all listeners of a ledger channel update.
   // It only notifies listeners if the new info is different from the previous info.
-  async Notify(info: LedgerChannelInfo): Promise<void> {
+  async notify(info: LedgerChannelInfo): Promise<void> {
     if (this.prev?.equal(info)) {
       return;
     }

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -477,8 +477,8 @@ export class Objective implements ObjectiveInterface {
 
   private hasFinalStateFromAlice(): boolean {
     const ok = this.v!.signedStateForTurnNum.has(FinalTurnNum);
-    const ss = this.v!.signedStateForTurnNum.get(FinalTurnNum)!;
-    return ok && ss.state().isFinal && !this.isZero(ss.signatures()[0]);
+    const ss = this.v!.signedStateForTurnNum.get(FinalTurnNum);
+    return ok && ss!.state().isFinal && !this.isZero(ss!.signatures()[0]);
   }
 
   // Crank inspects the extended state and declares a list of Effects to be executed.


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Implement classes ChannelNotifier, PaymentChannelListeners, LedgerChannelListeners
- Implement MemStore.getChannelByIds
- Implement P2PMessageService methods addPeers and close