### PR TITLE
Changes to connect browser client with go-nitro

### DIFF
--- a/packages/example-web-app/README.md
+++ b/packages/example-web-app/README.md
@@ -6,7 +6,11 @@ Instructions to run two instances of `ts-nitro` clients in a browser environment
 
 Run relay node using v2 watcher
 
-## Setup
+## `ts-nitro` - `ts-nitro`
+
+Instructions to run two instances of `ts-nitro` clients in browser environment and create a ledger channel between them
+
+### Setup
 
 * In root of the repo, install depedencies:
 
@@ -50,9 +54,9 @@ Run relay node using v2 watcher
 
   yarn start
   ```
-## Run
+### Run
 
-* Open app in 2 different browsers
+* Open [app](http://localhost:3000) in 2 different browsers
 
 * Open console in browser inspect and enable debug logs by setting `localStorage.debug = 'ts-nitro:*'`
 
@@ -75,6 +79,65 @@ Run relay node using v2 watcher
     ```
     ts-nitro:engine Objective DirectFunding-0x841b8725d82bdbd67650b101183143dcccf29083e0b127ca90f0f8f81cfd8978 is complete & returned to API +22ms
     ```
+
+## `ts-nitro` - `go-nitro`
+
+Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and create a ledger channel between them
+
+### Setup
+
+* Follow the setup steps in the [`ts-nitro`-`ts-nitro`](#setup) section
+
+* In `statechannels/go-nitro`, install dependencies:
+
+  ```bash
+  go mod tidy
+  ```
+
+### Run
+
+* Run a `go-nitro` client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
+
+  ```bash
+  # In statechannels/go-nitro
+  go run . -msgport 3006 -wsmsgport 5006 -rpcport 4006 -pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 -chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d -naaddress 0x5FbDB2315678afecb367f032d93F642f64180aa3 -vpaaddress 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 -caaddress 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+
+  # Expected output:
+  # Initialising mem store...
+  # Initializing chain service and connecting to ws://127.0.0.1:8545...
+  # Initializing message service on tcp port 3006 and websocket port 5006...
+  # P2PMessageService started with Peer Id: 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes
+  # Address: 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
+  # {"level":"debug","engine":"0xBBB676","time":1687775511148,"caller":"engine.go:151","message":"Constructed Engine"}
+  # Initializing websocket RPC transport...
+  # Nitro as a Service listening on port 4006
+  ```
+
+* Open [app](http://localhost:3000) in browser
+
+* Open console in browser inspect and enable debug logs by setting `localStorage.debug = 'ts-nitro:*'`
+
+* Refresh the app for enabling logs
+
+* Call method `setupClient('alice')`
+
+* Call method `addPeerByMultiaddr` to connect to client Bob
+
+  ```
+  addPeerByMultiaddr('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94', '/ip4/127.0.0.1/tcp/5006/ws/p2p/16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes')
+  ```
+
+* Call method `directFund` with address of client Bob and check logs
+
+  ```
+  directFund('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94')
+  ```
+
+* Final expected log
+
+  ```
+  ts-nitro:engine Objective DirectFunding-0x841b8725d82bdbd67650b101183143dcccf29083e0b127ca90f0f8f81cfd8978 is complete & returned to API +22ms
+  ```
 
 ## Getting Started with Create React App
 

--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -12,6 +12,7 @@ import {
   BOB_CHAIN_PK,
   DEFAULT_CHAIN_URL
 } from '@cerc-io/util';
+import { multiaddr } from '@multiformats/multiaddr';
 
 import logo from './logo.svg';
 import './App.css';
@@ -19,10 +20,11 @@ import { createP2PMessageService } from './utils';
 
 declare global {
   interface Window {
-    client: Client;
-    msgService: P2PMessageService;
     setupClient: (name: string) => Promise<void>
-    directFund: (clientAddress: string) => Promise<void>
+    client?: Client;
+    msgService?: P2PMessageService;
+    directFund?: (clientAddress: string) => Promise<void>
+    addPeerByMultiaddr?: (address: string, multiaddrString: string) => Promise<void>
   }
 }
 
@@ -55,18 +57,23 @@ function App() {
 
       const outcome = createOutcome(
         asset,
-        window.client.address,
+        window.client!.address,
         counterParty,
         1_000_000,
       )
       
-      const response = await window.client.createLedgerChannel(
+      const response = await window.client!.createLedgerChannel(
         counterParty,
         challengeDuration,
         outcome,
       );
 
       console.log(response)
+    }
+
+    window.addPeerByMultiaddr = async (address: string, multiaddrString: string) => {
+      const multi = multiaddr(multiaddrString);
+      await window.msgService!.addPeerByMultiaddr(address, multi);
     }
   }, []);
 

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
@@ -1,6 +1,8 @@
 import type { ReadChannel } from '@nodeguy/channel';
 // @ts-expect-error
 import type { PeerId } from '@libp2p/interface-peer-id';
+// @ts-expect-error
+import { Multiaddr } from '@multiformats/multiaddr';
 
 import { Message } from '../../../../protocols/messages';
 import { Address } from '../../../../types/types';
@@ -71,5 +73,11 @@ export class P2PMessageService implements MessageService {
   // We ignore peers that are ourselves.
   async addPeers(peers: PeerInfo[]) {
     return this.baseP2PMessageService.addPeers(peers);
+  }
+
+  // Custom method to add peer using multiaddr
+  // Used for adding peers that support transports other than tcp
+  async addPeerByMultiaddr(clientAddress: Address, multiaddr: Multiaddr) {
+    return this.baseP2PMessageService.addPeerByMultiaddr(clientAddress, multiaddr);
   }
 }

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
@@ -89,8 +89,8 @@ export class BaseP2PMessageService implements MessageService {
 
   private logger: debug.Debugger = log;
 
-  // Custom channel for pushing peer id to which self info was sent
-  private sentPeerInfo = Channel<PeerId>(BUFFER_SIZE);
+  // Custom channel storing ids of peers to whom self info has been sent
+  private sentInfoToPeer = Channel<PeerId>(BUFFER_SIZE);
 
   constructor(params: ConstructorOptions) {
     Object.assign(this, params);
@@ -190,7 +190,7 @@ export class BaseP2PMessageService implements MessageService {
       stream.close();
 
       // Use a non-blocking channel send in case no one is listening
-      this.sentPeerInfo.push(data.peerId);
+      this.sentInfoToPeer.push(data.peerId);
     } catch (err) {
       this.checkError(err as Error);
     }
@@ -470,7 +470,7 @@ export class BaseP2PMessageService implements MessageService {
 
     // Wait for sending self info to all connected remote peers
     while (connections.length) {
-      const peerId = await this.sentPeerInfo.shift();
+      const peerId = await this.sentInfoToPeer.shift();
       connections = connections.filter((connection) => !peerId.equals(connection.remotePeer));
       this.logger(`Connected and sent info to peer ${peerId.toString()}`);
     }

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
@@ -19,6 +19,8 @@ import type { IncomingStreamData } from '@libp2p/interface-registrar';
 import type { PeerId } from '@libp2p/interface-peer-id';
 // @ts-expect-error
 import type { PeerProtocolsChangeData } from '@libp2p/interface-peer-store';
+// @ts-expect-error
+import { Multiaddr } from '@multiformats/multiaddr';
 
 import { SafeSyncMap } from '../../../../internal/safesync/safesync';
 import { Message, deserializeMessage } from '../../../../protocols/messages';
@@ -87,8 +89,8 @@ export class BaseP2PMessageService implements MessageService {
 
   private logger: debug.Debugger = log;
 
-  // Custom channel to push peer info after sending to remote peer
-  private sentPeerInfo = Channel<BasicPeerInfo>(BUFFER_SIZE);
+  // Custom channel for pushing peer id to which self info was sent
+  private sentPeerInfo = Channel<PeerId>(BUFFER_SIZE);
 
   constructor(params: ConstructorOptions) {
     Object.assign(this, params);
@@ -186,6 +188,9 @@ export class BaseP2PMessageService implements MessageService {
 
       await this.sendPeerInfo(stream);
       stream.close();
+
+      // Use a non-blocking channel send in case no one is listening
+      this.sentPeerInfo.push(data.peerId);
     } catch (err) {
       this.checkError(err as Error);
     }
@@ -258,9 +263,6 @@ export class BaseP2PMessageService implements MessageService {
       [uint8ArrayFromString(raw + DELIMITER)],
       stream.sink,
     );
-
-    // Use a non-blocking channel send in case no one is listening
-    this.sentPeerInfo.push(peerInfo);
   }
 
   // receivePeerInfo receives peer info from the given stream
@@ -416,10 +418,39 @@ export class BaseP2PMessageService implements MessageService {
     }
   }
 
+  // Custom method to add peer using multiaddr
+  // Used for adding peers that support transports other than tcp
+  async addPeerByMultiaddr(clientAddress: Address, multiaddr: Multiaddr) {
+    // Ignore ourselves
+    if (clientAddress === this.me) {
+      return;
+    }
+
+    const peerIdString = multiaddr.getPeerId();
+    assert(peerIdString);
+    const { peerIdFromString } = await import('@libp2p/peer-id');
+    const peerId = peerIdFromString(peerIdString);
+
+    await this.p2pHost.peerStore.addressBook.add(
+      peerId,
+      [multiaddr],
+    );
+
+    this.peers!.store(clientAddress, { id: peerId, address: clientAddress });
+
+    // Call custom method to send self info to remote peers so that they can send messages
+    await this.connectAndSendPeerInfos([
+      {
+        id: peerId,
+        address: clientAddress,
+      },
+    ]);
+  }
+
   // Custom method to dial and connect to peers
   // It also waits for self to send info to remote peer
   // This method is only required by addPeers method to exchange peer info
-  private async connectAndSendPeerInfos(peers: PeerInfo[]) {
+  private async connectAndSendPeerInfos(peers: BasicPeerInfo[]) {
     const connectionPromises = peers.map(async (peerInfo) => {
       // Dial peer to connect and then trigger change:protocols event which would send peer info
       return this.p2pHost!.dial(peerInfo.id);
@@ -439,8 +470,9 @@ export class BaseP2PMessageService implements MessageService {
 
     // Wait for sending self info to all connected remote peers
     while (connections.length) {
-      const peerInfo = await this.sentPeerInfo.shift();
-      connections = connections.filter((connection) => peerInfo.id.equals(connection.remotePeer));
+      const peerId = await this.sentPeerInfo.shift();
+      connections = connections.filter((connection) => !peerId.equals(connection.remotePeer));
+      this.logger(`Connected and sent info to peer ${peerId.toString()}`);
     }
   }
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Implement `addPeerByMultiaddr` in message service
  - Use method to connect to a go-nitro client from browser