### PR TITLE
Make bigint and byte slice fields optional and handle serialization

### DIFF
--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -847,7 +847,7 @@ export class SignedProposal {
     proposal: { type: 'class', value: Proposal },
     turnNum: { type: 'uint64' },
   };
-  
+
   static fromJSON(data: string): SignedProposal {
     // props has Signature properties
     const props = fromJSON(this.jsonEncodingMap, data);

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -283,7 +283,7 @@ export class LedgerOutcome {
 
     for (const allocation of sae.allocations.value) {
       if (allocation.allocationType === AllocationType.GuaranteeAllocationType) {
-        const gM = GuaranteeMetadata.decodeIntoGuaranteeMetadata(allocation.metadata ?? Buffer.alloc(0));
+        const gM = GuaranteeMetadata.decodeIntoGuaranteeMetadata(allocation.metadata);
         const guarantee: Guarantee = new Guarantee({
           amount: allocation.amount,
           _target: allocation.destination,

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -283,7 +283,7 @@ export class LedgerOutcome {
 
     for (const allocation of sae.allocations.value) {
       if (allocation.allocationType === AllocationType.GuaranteeAllocationType) {
-        const gM = GuaranteeMetadata.decodeIntoGuaranteeMetadata(allocation.metadata);
+        const gM = GuaranteeMetadata.decodeIntoGuaranteeMetadata(allocation.metadata ?? Buffer.alloc(0));
         const guarantee: Guarantee = new Guarantee({
           amount: allocation.amount,
           _target: allocation.destination,

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -58,7 +58,7 @@ export const Follower: LedgerIndex = 1;
 export class Balance {
   destination: Destination = new Destination();
 
-  amount?: bigint;
+  amount?: bigint = undefined;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     destination: { type: 'class', value: Destination },
@@ -115,7 +115,7 @@ interface GuaranteeOptions {
 // Guarantee is a convenient, ergonomic representation of a
 // single-asset Allocation of type 1, ie. a guarantee.
 export class Guarantee {
-  amount?: bigint;
+  amount?: bigint = undefined;
 
   _target: Destination = new Destination();
 
@@ -632,7 +632,7 @@ export class Add extends Guarantee {
   // LeftDeposit is the portion of the Add's amount that will be deducted from left participant's ledger balance.
   //
   // The right participant's deduction is computed as the difference between the guarantee amount and LeftDeposit.
-  leftDeposit?: bigint;
+  leftDeposit?: bigint = undefined;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     guarantee: { type: 'class', value: Guarantee },
@@ -699,7 +699,7 @@ export class Remove {
   // LeftAmount is the amount to be credited (in the ledger channel) to the participant specified as the "left" in the guarantee.
   //
   // The amount for the "right" participant is calculated as the difference between the guarantee amount and LeftAmount.
-  leftAmount?: bigint;
+  leftAmount?: bigint = undefined;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     target: { type: 'class', value: Destination },

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -58,7 +58,7 @@ export const Follower: LedgerIndex = 1;
 export class Balance {
   destination: Destination = new Destination();
 
-  amount: bigint = BigInt(0);
+  amount?: bigint;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     destination: { type: 'class', value: Destination },
@@ -83,7 +83,7 @@ export class Balance {
 
   // AsAllocation converts a Balance struct into the on-chain outcome.Allocation type.
   asAllocation(): Allocation {
-    const amount = BigInt(this.amount);
+    const amount = BigInt(this.amount!);
     return new Allocation({
       destination: this.destination,
       amount,
@@ -100,7 +100,7 @@ export class Balance {
   clone(): Balance {
     return new Balance({
       destination: _.cloneDeep(this.destination),
-      amount: BigInt(this.amount),
+      amount: BigInt(this.amount!),
     });
   }
 }
@@ -115,7 +115,7 @@ interface GuaranteeOptions {
 // Guarantee is a convenient, ergonomic representation of a
 // single-asset Allocation of type 1, ie. a guarantee.
 export class Guarantee {
-  amount: bigint = BigInt(0);
+  amount?: bigint;
 
   _target: Destination = new Destination();
 
@@ -136,7 +136,7 @@ export class Guarantee {
   }
 
   // NewGuarantee constructs a new guarantee.
-  static newGuarantee(amount: bigint, target: Destination, left: Destination, right: Destination): Guarantee {
+  static newGuarantee(amount: bigint | undefined, target: Destination, left: Destination, right: Destination): Guarantee {
     return new Guarantee({
       amount, _target: target, left, right,
     });
@@ -153,7 +153,7 @@ export class Guarantee {
   // Clone returns a deep copy of the receiver.
   clone(): Guarantee {
     return new Guarantee({
-      amount: BigInt(this.amount),
+      amount: BigInt(this.amount!),
       _target: _.cloneDeep(this._target),
       left: _.cloneDeep(this.left),
       right: _.cloneDeep(this.right),
@@ -177,7 +177,7 @@ export class Guarantee {
 
   // AsAllocation converts a Balance struct into the on-chain outcome.Allocation type
   asAllocation(): Allocation {
-    const amount = BigInt(this.amount);
+    const amount = BigInt(this.amount!);
 
     return new Allocation({
       destination: this._target,
@@ -333,18 +333,18 @@ export class LedgerOutcome {
 
     const leader = new Balance({
       destination: _.cloneDeep(this._leader.destination),
-      amount: BigInt(this._leader.amount), // Create a new BigInt instance
+      amount: BigInt(this._leader.amount!), // Create a new BigInt instance
     });
 
     const follower = new Balance({
       destination: _.cloneDeep(this._follower.destination),
-      amount: BigInt(this._follower.amount), // Create a new BigInt instance
+      amount: BigInt(this._follower.amount!), // Create a new BigInt instance
     });
 
     const guarantees = new Map<Bytes32, Guarantee>();
     for (const [d, g] of this.guarantees.entries()) {
       const g2 = g;
-      g2.amount = BigInt(g.amount);
+      g2.amount = BigInt(g.amount!);
       guarantees.set(d, g2);
     }
 
@@ -498,15 +498,15 @@ export class Vars {
       right = o._leader;
     }
 
-    if (p.leftDeposit > p.amount) {
+    if (p.leftDeposit! > p.amount!) {
       throw ErrInvalidDeposit;
     }
 
-    if (p.leftDeposit > left.amount) {
+    if (p.leftDeposit! > left.amount!) {
       throw ErrInsufficientFunds;
     }
 
-    if (p.rightDeposit() > right.amount) {
+    if (p.rightDeposit() > right.amount!) {
       throw ErrInsufficientFunds;
     }
 
@@ -519,11 +519,11 @@ export class Vars {
 
     // Adjust balances
     if (_.isEqual(o._leader.destination, p.left)) {
-      o._leader.amount -= p.leftDeposit;
-      o._follower.amount -= rightDeposit;
+      o._leader.amount = BigInt(o._leader.amount!) - BigInt(p.leftDeposit!);
+      o._follower.amount = BigInt(o._follower.amount!) - rightDeposit;
     } else {
-      o._follower.amount -= p.leftDeposit;
-      o._leader.amount -= rightDeposit;
+      o._follower.amount = BigInt(o._follower.amount!) - BigInt(p.leftDeposit!);
+      o._leader.amount = BigInt(o._leader.amount!) - rightDeposit;
     }
 
     // Include guarantee
@@ -554,7 +554,7 @@ export class Vars {
       throw ErrGuaranteeNotFound;
     }
 
-    if (p.leftAmount > guarantee.amount) {
+    if (p.leftAmount! > guarantee.amount!) {
       throw ErrInvalidAmount;
     }
 
@@ -563,16 +563,16 @@ export class Vars {
     // Increase the turn number
     this.turnNum += BigInt(1);
 
-    const rightAmount = guarantee.amount - p.leftAmount;
+    const rightAmount = BigInt(guarantee.amount!) - BigInt(p.leftAmount!);
 
     // Adjust balances
 
     if (_.isEqual(o._leader.destination, guarantee.left)) {
-      o._leader.amount += p.leftAmount;
-      o._follower.amount += rightAmount;
+      o._leader.amount = BigInt(o._leader.amount!) + BigInt(p.leftAmount!);
+      o._follower.amount = BigInt(o._follower.amount!) + rightAmount;
     } else {
-      o._leader.amount += rightAmount;
-      o._follower.amount += p.leftAmount;
+      o._leader.amount = BigInt(o._leader.amount!) + rightAmount;
+      o._follower.amount = BigInt(o._follower.amount!) + BigInt(p.leftAmount!);
     }
 
     // Remove the guarantee
@@ -632,7 +632,7 @@ export class Add extends Guarantee {
   // LeftDeposit is the portion of the Add's amount that will be deducted from left participant's ledger balance.
   //
   // The right participant's deduction is computed as the difference between the guarantee amount and LeftDeposit.
-  leftDeposit: bigint = BigInt(0);
+  leftDeposit?: bigint;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     guarantee: { type: 'class', value: Guarantee },
@@ -669,23 +669,23 @@ export class Add extends Guarantee {
 
     return new Add({
       ...super.clone(),
-      leftDeposit: BigInt(this.leftDeposit),
+      leftDeposit: BigInt(this.leftDeposit!),
     });
   }
 
   // RightDeposit computes the deposit from the right participant such that
   // a.LeftDeposit + a.RightDeposit() fully funds a's guarantee.BalanceBalance
   rightDeposit(): bigint {
-    const result = this.amount - this.leftDeposit;
+    const result = BigInt(this.amount!) - BigInt(this.leftDeposit!);
     return result;
   }
 
   equal(a2: Add): boolean {
-    return _.isEqual(this, a2);
+    return _.isEqual((this as Guarantee), (a2 as Guarantee)) && this.leftDeposit === a2.leftDeposit;
   }
 
   // NewAdd constructs a new Add proposal.
-  static newAdd(g: Guarantee, leftDeposit: bigint): Add {
+  static newAdd(g: Guarantee, leftDeposit?: bigint): Add {
     return new Add({
       _target: g._target, amount: g.amount, left: g.left, right: g.right, leftDeposit,
     });
@@ -700,7 +700,7 @@ export class Remove {
   // LeftAmount is the amount to be credited (in the ledger channel) to the participant specified as the "left" in the guarantee.
   //
   // The amount for the "right" participant is calculated as the difference between the guarantee amount and LeftAmount.
-  leftAmount: bigint = BigInt(0);
+  leftAmount?: bigint;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     target: { type: 'class', value: Destination },
@@ -736,12 +736,12 @@ export class Remove {
 
     return new Remove({
       target: _.cloneDeep(this.target),
-      leftAmount: BigInt(this.leftAmount),
+      leftAmount: BigInt(this.leftAmount!),
     });
   }
 
   // NewRemove constructs a new Remove proposal.
-  static newRemove(target: Destination, leftAmount: bigint): Remove {
+  static newRemove(target: Destination, leftAmount?: bigint): Remove {
     return new Remove({ target, leftAmount });
   }
 }
@@ -818,12 +818,12 @@ export class Proposal {
   }
 
   // NewAddProposal constucts a proposal with a valid Add proposal and empty remove proposal.
-  static newAddProposal(ledgerID: Destination, g: Guarantee, leftDeposit: bigint): Proposal {
+  static newAddProposal(ledgerID: Destination, g: Guarantee, leftDeposit?: bigint): Proposal {
     return new Proposal({ toAdd: Add.newAdd(g, leftDeposit), ledgerID });
   }
 
   // NewRemoveProposal constucts a proposal with a valid Remove proposal and empty Add proposal.
-  static newRemoveProposal(ledgerID: Destination, target: Destination, leftAmount: bigint): Proposal {
+  static newRemoveProposal(ledgerID: Destination, target: Destination, leftAmount?: bigint): Proposal {
     return new Proposal({ toRemove: Remove.newRemove(target, leftAmount), ledgerID });
   }
 }
@@ -847,7 +847,7 @@ export class SignedProposal {
     proposal: { type: 'class', value: Proposal },
     turnNum: { type: 'uint64' },
   };
-
+  
   static fromJSON(data: string): SignedProposal {
     // props has Signature properties
     const props = fromJSON(this.jsonEncodingMap, data);

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -662,10 +662,9 @@ export class Add extends Guarantee {
 
   // Clone returns a deep copy of the receiver.
   clone(): Add {
-    // TODO: Make bigint fields optional?
-    // if a == nil || a.LeftDeposit == nil {
-    //   return Add{}
-    // }
+    if (this.leftDeposit === undefined) {
+      return new Add({});
+    }
 
     return new Add({
       ...super.clone(),
@@ -729,10 +728,9 @@ export class Remove {
 
   // Clone returns a deep copy of the receiver.
   clone(): Remove {
-    // TODO: Make bigint fields optional?
-    // if r == nil || r.LeftAmount == nil {
-    //   return Remove{}
-    // }
+    if (this.leftAmount === undefined) {
+      return new Remove({});
+    }
 
     return new Remove({
       target: _.cloneDeep(this.target),

--- a/packages/nitro-client/src/channel/state/outcome/allocation.ts
+++ b/packages/nitro-client/src/channel/state/outcome/allocation.ts
@@ -26,7 +26,7 @@ export class Allocation {
   allocationType: AllocationType = AllocationType.NormalAllocationType;
 
   // Custom metadata (optional field, can be zero bytes). This can be used flexibly by different protocols.
-  metadata: Buffer = Buffer.alloc(0);
+  metadata: Buffer | null = null;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     destination: { type: 'class', value: Destination },
@@ -48,7 +48,7 @@ export class Allocation {
     destination?: Destination,
     amount?: bigint,
     allocationType?: AllocationType,
-    metadata?: Buffer,
+    metadata?: Buffer | null,
   }) {
     Object.assign(this, params);
   }
@@ -59,7 +59,7 @@ export class Allocation {
     return _.isEqual(this.destination, b.destination)
     && this.allocationType === b.allocationType
     && this.amount === b.amount
-    && this.metadata.compare(b.metadata) === 0;
+    && _.isEqual(this.metadata, b.metadata);
   }
 
   // Clone returns a deep copy of the receiver.
@@ -68,7 +68,7 @@ export class Allocation {
       destination: _.cloneDeep(this.destination),
       amount: this.amount,
       allocationType: this.allocationType,
-      metadata: Buffer.from(this.metadata),
+      metadata: _.cloneDeep(this.metadata),
     });
   }
 }

--- a/packages/nitro-client/src/channel/state/outcome/allocation.ts
+++ b/packages/nitro-client/src/channel/state/outcome/allocation.ts
@@ -20,7 +20,7 @@ export class Allocation {
   destination: Destination = new Destination();
 
   // An amount of a particular asset
-  amount?: bigint;
+  amount?: bigint = undefined;
 
   // Directs calling code on how to interpret the allocation
   allocationType: AllocationType = AllocationType.NormalAllocationType;

--- a/packages/nitro-client/src/channel/state/outcome/deposit-safety.ts
+++ b/packages/nitro-client/src/channel/state/outcome/deposit-safety.ts
@@ -17,7 +17,7 @@ export const singleAssetExitDepositSafetyThreshold = (singleAssetExit: SingleAss
       return sum;
     }
 
-    sum += allocation.amount;
+    sum += BigInt(allocation.amount!);
   }
 
   return sum;

--- a/packages/nitro-client/src/channel/state/outcome/exit.ts
+++ b/packages/nitro-client/src/channel/state/outcome/exit.ts
@@ -19,7 +19,7 @@ type AssetType = number;
 
 export type AssetMetadata = {
   assetType: AssetType;
-  metadata: Buffer;
+  metadata: Buffer | null;
 };
 
 const assetMetadataJsonEncodingMap: Record<string, FieldDescription> = {
@@ -33,7 +33,7 @@ export class SingleAssetExit {
   asset: Address = ethers.constants.AddressZero;
 
   // Can be used to encode arbitrary additional information that applies to all allocations.
-  assetMetadata: AssetMetadata = { assetType: 0, metadata: Buffer.alloc(0) };
+  assetMetadata: AssetMetadata = { assetType: 0, metadata: null };
 
   allocations: Allocations = new Allocations([]);
 
@@ -64,7 +64,7 @@ export class SingleAssetExit {
 
   // Equal returns true if the supplied SingleAssetExit is deeply equal to the receiver.
   equal(r: SingleAssetExit): boolean {
-    return this.assetMetadata.metadata.compare(r.assetMetadata.metadata) === 0
+    return _.isEqual(this.assetMetadata.metadata, r.assetMetadata.metadata)
     && this.assetMetadata.assetType === r.assetMetadata.assetType
     && this.asset === r.asset
     && this.allocations.equal(r.allocations);

--- a/packages/nitro-client/src/channel/state/outcome/guarantee.ts
+++ b/packages/nitro-client/src/channel/state/outcome/guarantee.ts
@@ -28,8 +28,8 @@ export class GuaranteeMetadata {
   }
 
   // Decode returns a GuaranteeMetaData from an abi encoding
-  static decodeIntoGuaranteeMetadata(m: Buffer): GuaranteeMetadata {
-    const { left, right } = decodeGuaranteeData(m.toString());
+  static decodeIntoGuaranteeMetadata(m: Buffer | null): GuaranteeMetadata {
+    const { left, right } = decodeGuaranteeData((m ?? Buffer.alloc(0)).toString());
     return new GuaranteeMetadata({
       left: new Destination(left),
       right: new Destination(right),

--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -82,7 +82,7 @@ export class FixedPart {
 
 // VariablePart contains the subset of State data which can change with each state update.
 export class VariablePart {
-  appData: Buffer = Buffer.alloc(0);
+  appData: Buffer | null = null;
 
   outcome: Exit = new Exit([]);
 
@@ -92,7 +92,7 @@ export class VariablePart {
 
   constructor(
     params: {
-      appData?: Buffer,
+      appData?: Buffer | null,
       outcome?: Exit,
       turnNum?: Uint64,
       isFinal?: boolean
@@ -113,7 +113,7 @@ export class State {
   // TODO: uint32 replacement
   challengeDuration: number = 0;
 
-  appData: Buffer = Buffer.alloc(0);
+  appData: Buffer | null = null;
 
   outcome: Exit = new Exit([]);
 
@@ -147,7 +147,7 @@ export class State {
       channelNonce?: Uint64,
       appDefinition?: Address,
       challengeDuration?: number,
-      appData?: Buffer,
+      appData?: Buffer | null,
       outcome?: Exit,
       turnNum?: Uint64,
       isFinal?: boolean
@@ -169,8 +169,8 @@ export class State {
   // VariablePart returns the VariablePart of the State
   variablePart(): VariablePart {
     return new VariablePart({
-      appData: Buffer.from(this.appData),
-      outcome: _.cloneDeep(this.outcome),
+      appData: this.appData,
+      outcome: this.outcome,
       turnNum: this.turnNum,
       isFinal: this.isFinal,
     });
@@ -221,7 +221,7 @@ export class State {
     && this.channelNonce === r.channelNonce
     && this.appDefinition === r.appDefinition
     && this.challengeDuration === r.challengeDuration
-    && this.appData.compare(r.appData) === 0
+    && _.isEqual(this.appData, r.appData)
     && this.outcome.equal(r.outcome)
     && this.turnNum === r.turnNum
     && this.isFinal === r.isFinal;
@@ -265,12 +265,12 @@ export class State {
             destination: allocation.destination.value,
             amount: allocation.amount!.toString(),
             allocationType: allocation.allocationType,
-            metadata: `0x${bytes2Hex(allocation.metadata)}`,
+            metadata: `0x${bytes2Hex(allocation.metadata ?? Buffer.alloc(0))}`,
           };
         }),
         assetMetadata: {
           assetType: singleAssetExit.assetMetadata.assetType,
-          metadata: `0x${bytes2Hex(singleAssetExit.assetMetadata.metadata)}`,
+          metadata: `0x${bytes2Hex(singleAssetExit.assetMetadata.metadata ?? Buffer.alloc(0))}`,
         },
       };
     });
@@ -281,7 +281,7 @@ export class State {
       appDefinition: this.appDefinition,
       challengeDuration: this.challengeDuration,
       outcome: stateOutcome,
-      appData: `0x${bytes2Hex(this.appData)}`,
+      appData: `0x${bytes2Hex(this.appData ?? Buffer.alloc(0))}`,
       turnNum: Number(this.turnNum),
       isFinal: this.isFinal,
     };

--- a/packages/nitro-client/src/channel/state/state.ts
+++ b/packages/nitro-client/src/channel/state/state.ts
@@ -263,7 +263,7 @@ export class State {
         allocations: singleAssetExit.allocations.value.map((allocation) => {
           return {
             destination: allocation.destination.value,
-            amount: allocation.amount.toString(),
+            amount: allocation.amount!.toString(),
             allocationType: allocation.allocationType,
             metadata: `0x${bytes2Hex(allocation.metadata)}`,
           };

--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -180,7 +180,7 @@ export class Client {
   }
 
   // Pay will send a signed voucher to the payee that they can redeem for the given amount.
-  async pay(channelId: Destination, amount: bigint) {
+  async pay(channelId: Destination, amount?: bigint) {
     assert(this.engine.paymentRequestsFromAPI);
     // Send the event to the engine
     await this.engine.paymentRequestsFromAPI.push({ channelId, amount });

--- a/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
@@ -9,7 +9,7 @@ import {
 export function convertAssetMetadata(am: AssetMetadata): ExitFormat.AssetMetadataStruct {
   return {
     assetType: am.assetType,
-    metadata: am.metadata,
+    metadata: am.metadata ?? Buffer.alloc(0),
   };
 }
 
@@ -18,7 +18,7 @@ export function convertAllocations(as: Allocations): ExitFormat.AllocationStruct
     destination: a.destination.value,
     amount: a.amount!,
     allocationType: a.allocationType,
-    metadata: a.metadata,
+    metadata: a.metadata ?? Buffer.alloc(0),
   }));
 }
 
@@ -41,7 +41,7 @@ export function convertFixedPart(fp: FixedPart): INitroTypes.FixedPartStruct {
 
 export function convertVariablePart(vp: VariablePart): INitroTypes.VariablePartStruct {
   return {
-    appData: vp.appData,
+    appData: vp.appData ?? Buffer.alloc(0),
     turnNum: BigInt(vp.turnNum),
     isFinal: vp.isFinal,
     outcome: convertOutcome(vp.outcome!),

--- a/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
@@ -16,7 +16,7 @@ export function convertAssetMetadata(am: AssetMetadata): ExitFormat.AssetMetadat
 export function convertAllocations(as: Allocations): ExitFormat.AllocationStruct[] {
   return as.value.map((a): ExitFormat.AllocationStruct => ({
     destination: a.destination.value,
-    amount: a.amount,
+    amount: a.amount!,
     allocationType: a.allocationType,
     metadata: a.metadata,
   }));

--- a/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
@@ -39,20 +39,20 @@ interface AssetAndAmountConstructorOptions {
 class AssetAndAmount {
   assetAddress: Address = ethers.constants.AddressZero;
 
-  assetAmount: bigint = BigInt(0);
+  assetAmount?: bigint;
 
   constructor(params: AssetAndAmountConstructorOptions) {
     Object.assign(this, params);
   }
 
   string(): string {
-    return `${this.assetAmount.toString()} units of ${this.assetAddress} token`;
+    return `${this.assetAmount!.toString()} units of ${this.assetAddress} token`;
   }
 }
 
 // DepositedEvent is an internal representation of the deposited blockchain event
 export class DepositedEvent extends CommonEvent {
-  nowHeld: bigint = BigInt(0);
+  nowHeld?: bigint;
 
   // Workaround for extending multiple classes in TypeScript
   assetAndAmount: AssetAndAmount;
@@ -68,7 +68,7 @@ export class DepositedEvent extends CommonEvent {
     this.assetAndAmount = new AssetAndAmount(assetAndAmountParams);
   }
 
-  static newDepositedEvent(channelId: Destination, blockNum: string, assetAddress: Address, assetAmount: bigint, nowHeld: bigint): DepositedEvent {
+  static newDepositedEvent(channelId: Destination, blockNum: string, assetAddress: Address, assetAmount?: bigint, nowHeld?: bigint): DepositedEvent {
     return new DepositedEvent(
       {
         _channelID: channelId,
@@ -84,7 +84,7 @@ export class DepositedEvent extends CommonEvent {
 
   string(): string {
     /* eslint-disable max-len */
-    return `Deposited ${this.assetAndAmount.string()} leaving ${this.nowHeld.toString()} now held against channel ${this.channelID().string()} at Block ${this.blockNum}`;
+    return `Deposited ${this.assetAndAmount.string()} leaving ${this.nowHeld!.toString()} now held against channel ${this.channelID().string()} at Block ${this.blockNum}`;
   }
 }
 
@@ -128,7 +128,7 @@ export class AllocationUpdatedEvent extends CommonEvent {
     return `Channel ${this.channelID().string()} has had allocation updated to ${this.assetAndAmount.string()} at Block ${this.blockNum}`;
   }
 
-  static newAllocationUpdatedEvent(channelId: Destination, blockNum: string, assetAddress: Address, assetAmount: bigint): AllocationUpdatedEvent {
+  static newAllocationUpdatedEvent(channelId: Destination, blockNum: string, assetAddress: Address, assetAmount: bigint | undefined): AllocationUpdatedEvent {
     return new AllocationUpdatedEvent({ _channelID: channelId, blockNum }, { assetAddress, assetAmount });
   }
 

--- a/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/chainservice.ts
@@ -39,7 +39,7 @@ interface AssetAndAmountConstructorOptions {
 class AssetAndAmount {
   assetAddress: Address = ethers.constants.AddressZero;
 
-  assetAmount?: bigint;
+  assetAmount?: bigint = undefined;
 
   constructor(params: AssetAndAmountConstructorOptions) {
     Object.assign(this, params);
@@ -52,7 +52,7 @@ class AssetAndAmount {
 
 // DepositedEvent is an internal representation of the deposited blockchain event
 export class DepositedEvent extends CommonEvent {
-  nowHeld?: bigint;
+  nowHeld?: bigint = undefined;
 
   // Workaround for extending multiple classes in TypeScript
   assetAndAmount: AssetAndAmount;

--- a/packages/nitro-client/src/client/engine/chainservice/eth-chain-helpers.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/eth-chain-helpers.ts
@@ -7,7 +7,12 @@ import { Address } from '../../../types/types';
 import { Destination } from '../../../types/destination';
 
 // getAssetHoldings reads on-chain holdings for a channel,asset address, and block number
-async function getAssetHoldings(na: NitroAdjudicator, assetAddress: Address, blockNumber: bigint, channelId: Destination): Promise<bigint> {
+async function getAssetHoldings(
+  na: NitroAdjudicator,
+  assetAddress: Address,
+  blockNumber: bigint | undefined,
+  channelId: Destination,
+): Promise<bigint> {
   const amount = await na.holdings(assetAddress, channelId.value, { blockTag: Number(blockNumber) });
   return amount.toBigInt();
 }
@@ -29,7 +34,7 @@ export async function getChainHolding(
 }
 
 // assetAddressForIndex uses the input parameters of a transaction to map an asset index to an asset address
-function assetAddressForIndex(na: NitroAdjudicator, tx: Transaction, index: bigint): Address {
+function assetAddressForIndex(na: NitroAdjudicator, tx: Transaction, index?: bigint): Address {
   const abiInterface = na.interface;
   const params = decodeTxParams(abiInterface, tx);
 

--- a/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/eth-chainservice.ts
@@ -50,8 +50,8 @@ interface EthChain {
 }
 
 interface BlockRange {
-  from: bigint;
-  to: bigint;
+  from?: bigint;
+  to?: bigint;
 }
 
 export class EthChainService implements ChainService {
@@ -385,7 +385,7 @@ export class EthChainService implements ChainService {
 
   // splitBlockRange takes a BlockRange and chunks it into a slice of BlockRanges, each having an interval no larger than the passed interval.
   // TODO: Implement and remove void
-  private splitBlockRange(total: BlockRange, maxInterval: bigint): BlockRange[] | void {}
+  private splitBlockRange(total: BlockRange, maxInterval?: bigint): BlockRange[] | void {}
 
   // eventFeed returns the out chan, and narrows the type so that external consumers may only receive on it.
   eventFeed(): ReadChannel<ChainEvent> {

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -78,7 +78,7 @@ const Outgoing: MessageDirection = 'Outgoing';
 
 export type PaymentRequest = {
   channelId: Destination
-  amount: bigint
+  amount?: bigint
 };
 
 // EngineEvent is a struct that contains a list of changes caused by handling a message/chain event/api event
@@ -495,8 +495,8 @@ export class Engine {
           return [new EngineEvent(), new Error(`could not fetch channel for voucher ${voucher}`)];
         }
 
-        let paid: bigint;
-        let remaining: bigint;
+        let paid: bigint | undefined;
+        let remaining: bigint | undefined;
         try {
           [paid, remaining] = getVoucherBalance(c.id, this.vm);
         } catch (err) {
@@ -628,7 +628,7 @@ export class Engine {
         }
 
         case or instanceof VirtualDefundObjectiveRequest: {
-          let minAmount = BigInt(0);
+          let minAmount: bigint | undefined = BigInt(0);
           const request = or as VirtualDefundObjectiveRequest;
 
           if (this.vm!.channelRegistered(request.channelId)) {
@@ -906,9 +906,10 @@ export class Engine {
   private registerPaymentChannel(vfo: VirtualFundObjective): void {
     assert(vfo.v);
     const postfund = vfo.v.postFundState();
+    let startingBalance: bigint = BigInt(0);
 
     // TODO: Assumes one asset for now
-    const startingBalance = BigInt(postfund.outcome.value[0].allocations.value[0].amount);
+    startingBalance = BigInt(postfund.outcome.value[0].allocations.value[0].amount!);
 
     assert(this.vm);
 
@@ -1041,9 +1042,9 @@ export class Engine {
             throw new Error(`could not determine virtual channel id from objective ${id}: ${err}`);
           }
 
-          let minAmount = BigInt(0);
+          let minAmount: bigint | undefined = BigInt(0);
           if (this.vm.channelRegistered(vId)) {
-            let paid: bigint;
+            let paid: bigint | undefined;
             try {
               paid = this.vm.paid(vId);
             } catch (err) {

--- a/packages/nitro-client/src/client/engine/store/memstore.ts
+++ b/packages/nitro-client/src/client/engine/store/memstore.ts
@@ -436,7 +436,7 @@ export class MemStore implements Store {
 
         if (o.toMyLeft
           && o.toMyLeft.channel
-          && _.isEqual(o.toMyLeft.channel.id, zeroAddress)
+          && !_.isEqual(o.toMyLeft.channel.id, zeroAddress)
         ) {
           let left: ConsensusChannel;
           try {
@@ -450,7 +450,7 @@ export class MemStore implements Store {
 
         if (o.toMyRight
           && o.toMyRight.channel
-          && _.isEqual(o.toMyRight.channel.id, zeroAddress)
+          && !_.isEqual(o.toMyRight.channel.id, zeroAddress)
         ) {
           let right: ConsensusChannel;
           try {
@@ -478,7 +478,7 @@ export class MemStore implements Store {
         const zeroAddress = new Destination();
 
         if (o.toMyLeft
-          && _.isEqual(o.toMyLeft.id, zeroAddress)
+          && !_.isEqual(o.toMyLeft.id, zeroAddress)
         ) {
           let left: ConsensusChannel;
           try {
@@ -491,7 +491,7 @@ export class MemStore implements Store {
         }
 
         if (o.toMyRight
-          && _.isEqual(o.toMyRight.id, zeroAddress)
+          && !_.isEqual(o.toMyRight.id, zeroAddress)
         ) {
           let right: ConsensusChannel;
           try {

--- a/packages/nitro-client/src/client/query/query.ts
+++ b/packages/nitro-client/src/client/query/query.ts
@@ -31,8 +31,8 @@ const getPaymentChannelBalance = (participants: Address[], outcome: Exit): Payme
   const { asset } = sao;
   const payer = participants[0];
   const payee = participants[numParticipants - 1];
-  const paidSoFar = BigInt(sao.allocations.value[1].amount);
-  const remaining = BigInt(sao.allocations.value[0].amount);
+  const paidSoFar = BigInt(sao.allocations.value[1].amount!);
+  const remaining = BigInt(sao.allocations.value[0].amount!);
   return new PaymentChannelBalance({
     assetAddress: asset,
     payer,
@@ -47,9 +47,9 @@ const getLedgerBalanceFromState = (latest: State): LedgerChannelBalance => {
   const outcome = latest.outcome.value[0];
   const { asset } = outcome;
   const client = latest.participants[0];
-  const clientBalance = BigInt(outcome.allocations.value[0].amount);
+  const clientBalance = BigInt(outcome.allocations.value[0].amount!);
   const hub = latest.participants[1];
-  const hubBalance = BigInt(outcome.allocations.value[1].amount);
+  const hubBalance = BigInt(outcome.allocations.value[1].amount!);
 
   return new LedgerChannelBalance({
     assetAddress: asset,
@@ -68,9 +68,9 @@ const getLatestSupportedOrPreFund = (channel: Channel): State => {
   return channel.preFundState();
 };
 
-export const getVoucherBalance = (id: Destination, vm: VoucherManager): [bigint, bigint] => {
-  let paid: bigint = BigInt(0);
-  let remaining: bigint = BigInt(0);
+export const getVoucherBalance = (id: Destination, vm: VoucherManager): [bigint | undefined, bigint | undefined] => {
+  let paid: bigint | undefined = BigInt(0);
+  let remaining: bigint | undefined = BigInt(0);
 
   if (!vm.channelRegistered(id)) {
     return [paid, remaining];
@@ -82,7 +82,7 @@ export const getVoucherBalance = (id: Destination, vm: VoucherManager): [bigint,
   return [paid, remaining];
 };
 
-export const constructPaymentInfo = (c: Channel, paid: bigint, remaining: bigint): PaymentChannelInfo => {
+export const constructPaymentInfo = (c: Channel, paid?: bigint, remaining?: bigint): PaymentChannelInfo => {
   let status = getStatusFromChannel(c);
 
   // ADR 0009 allows for intermediaries to exit the protocol before receiving all signed post funds
@@ -95,9 +95,9 @@ export const constructPaymentInfo = (c: Channel, paid: bigint, remaining: bigint
   const latest = getLatestSupportedOrPreFund(c);
   const balance = getPaymentChannelBalance(c.participants, latest.outcome);
 
-  balance.paidSoFar = BigInt(paid);
+  balance.paidSoFar = paid;
 
-  balance.remainingFunds = BigInt(remaining);
+  balance.remainingFunds = remaining;
 
   return new PaymentChannelInfo({
     iD: c.id,

--- a/packages/nitro-client/src/client/query/types.ts
+++ b/packages/nitro-client/src/client/query/types.ts
@@ -21,9 +21,9 @@ export class PaymentChannelBalance {
 
   payer: Address = ethers.constants.AddressZero;
 
-  paidSoFar: bigint = BigInt(0);
+  paidSoFar?: bigint;
 
-  remainingFunds: bigint = BigInt(0);
+  remainingFunds?: bigint;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     assetAddress: { type: 'address' },
@@ -99,10 +99,9 @@ export class LedgerChannelBalance {
 
   client: Address = ethers.constants.AddressZero;
 
-  // TODO: hexutil.Big replacement
-  hubBalance: bigint = BigInt(0);
+  hubBalance?: bigint;
 
-  clientBalance: bigint = BigInt(0);
+  clientBalance?: bigint;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     assetAddress: { type: 'address' },

--- a/packages/nitro-client/src/client/query/types.ts
+++ b/packages/nitro-client/src/client/query/types.ts
@@ -21,9 +21,9 @@ export class PaymentChannelBalance {
 
   payer: Address = ethers.constants.AddressZero;
 
-  paidSoFar?: bigint;
+  paidSoFar?: bigint = undefined;
 
-  remainingFunds?: bigint;
+  remainingFunds?: bigint = undefined;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     assetAddress: { type: 'address' },
@@ -99,9 +99,9 @@ export class LedgerChannelBalance {
 
   client: Address = ethers.constants.AddressZero;
 
-  hubBalance?: bigint;
+  hubBalance?: bigint = undefined;
 
-  clientBalance?: bigint;
+  clientBalance?: bigint = undefined;
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     assetAddress: { type: 'address' },

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -26,7 +26,7 @@ import * as nitroAbi from '../abi/types';
 export class Voucher {
   channelId: Destination = new Destination();
 
-  amount: bigint = BigInt(0);
+  amount?: bigint;
 
   signature: Signature = zeroValueSignature;
 
@@ -71,7 +71,7 @@ export class Voucher {
     // Using util method from nitro-protocol instead of go-nitro port
     const sig = await signVoucher(
       {
-        amount: this.amount.toString(),
+        amount: this.amount!.toString(),
         channelId: this.channelId.string(),
       },
       wallet,
@@ -104,7 +104,7 @@ export class VoucherInfo {
 
   channelPayee: Address = ethers.constants.AddressZero;
 
-  startingBalance: bigint = BigInt(0);
+  startingBalance?: bigint;
 
   largestVoucher: Voucher = new Voucher({});
 
@@ -134,12 +134,12 @@ export class VoucherInfo {
   }
 
   // Paid is the amount of funds that already have been used as payments
-  paid(): bigint {
+  paid(): bigint | undefined {
     return this.largestVoucher.amount;
   }
 
   // Remaining returns the amount of funds left to be used as payments
-  remaining(): bigint {
-    return this.startingBalance - this.paid();
+  remaining(): bigint | undefined {
+    return BigInt(this.startingBalance!) - BigInt(this.paid()!);
   }
 }

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -26,7 +26,7 @@ import * as nitroAbi from '../abi/types';
 export class Voucher {
   channelId: Destination = new Destination();
 
-  amount?: bigint;
+  amount?: bigint = undefined;
 
   signature: Signature = zeroValueSignature;
 
@@ -104,7 +104,7 @@ export class VoucherInfo {
 
   channelPayee: Address = ethers.constants.AddressZero;
 
-  startingBalance?: bigint;
+  startingBalance?: bigint = undefined;
 
   largestVoucher: Voucher = new Voucher({});
 

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -73,7 +73,7 @@ const isInConsensusOrFinalState = (c: channel.Channel): boolean => {
 const createChannelFromConsensusChannel = (cc: ConsensusChannel): channel.Channel => {
   const c = channel.Channel.new(
     cc.consensusVars().asState(cc.supportedSignedState().state().fixedPart()),
-    Number(cc.myIndex),
+    cc.myIndex,
   );
 
   c.onChainFunding = cc.onChainFunding.clone();

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -556,7 +556,7 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
 
   appDefinition: Address = ethers.constants.AddressZero;
 
-  appData: Buffer = Buffer.alloc(0);
+  appData: Buffer | null = null;
 
   nonce: Uint64 = BigInt(0);
 
@@ -567,7 +567,7 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
     challengeDuration: number,
     outcome: Exit,
     appDefinition: Address,
-    appData?: Buffer,
+    appData?: Buffer | null,
     nonce: Uint64,
     objectiveStarted?: ReadWriteChannel<void>
   }) {

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -135,7 +135,7 @@ export class Objective implements ObjectiveInterface {
     request: ObjectiveRequest,
     preApprove: boolean,
     myAddress: Address,
-    chainId: bigint,
+    chainId: bigint | undefined,
     getChannels: GetChannelsByParticipantFunction,
     getTwoPartyConsensusLedger: GetTwoPartyConsensusLedgerFunction,
   ): Objective {
@@ -344,7 +344,7 @@ export class Objective implements ObjectiveInterface {
     const de = event;
 
     if (BigInt(de.blockNum) > updated.latestBlockNumber) {
-      updated.c!.onChainFunding.value.set(de.assetAndAmount.assetAddress, de.nowHeld);
+      updated.c!.onChainFunding.value.set(de.assetAndAmount.assetAddress, de.nowHeld!);
       updated.latestBlockNumber = BigInt(de.blockNum);
     }
 
@@ -605,7 +605,7 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
   }
 
   // Id returns the objective id for the request.
-  id(myAddress: Address, chainId: bigint): ObjectiveId {
+  id(myAddress: Address, chainId?: bigint): ObjectiveId {
     const fixedPart: FixedPart = new FixedPart({
       participants: [myAddress, this.counterParty],
       channelNonce: this.nonce,
@@ -617,7 +617,7 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
   }
 
   // Response computes and returns the appropriate response from the request.
-  response(myAddress: Address, chainId: bigint): ObjectiveResponse {
+  response(myAddress: Address, chainId?: bigint): ObjectiveResponse {
     const fixedPart = new FixedPart({
       participants: [myAddress, this.counterParty],
       channelNonce: this.nonce,

--- a/packages/nitro-client/src/protocols/interfaces.ts
+++ b/packages/nitro-client/src/protocols/interfaces.ts
@@ -157,7 +157,7 @@ export enum ObjectiveStatus {
 
 // ObjectiveRequest is a request to create a new objective.
 export interface ObjectiveRequest {
-  id (address: Address, chainId: bigint): ObjectiveId
+  id (address: Address, chainId?: bigint): ObjectiveId
   waitForObjectiveToStart (): void
   signalObjectiveStarted (): void
 }

--- a/packages/nitro-client/src/protocols/messages.ts
+++ b/packages/nitro-client/src/protocols/messages.ts
@@ -225,7 +225,7 @@ export class Message {
         };
       }),
       payments: this.payments.map((p): PaymentSummary => ({
-        amount: p.amount,
+        amount: p.amount!,
         channelId: p.channelId.string(),
       })),
       rejectedObjectives: this.rejectedObjectives,

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -108,8 +108,8 @@ export function validateFinalOutcome(
   const initialBobAmount = initialOutcome.allocations.value[1].amount;
   const finalAliceAmount = finalOutcome.allocations.value[0].amount;
   const finalBobAmount = finalOutcome.allocations.value[1].amount;
-  const paidToBob = finalBobAmount - initialBobAmount;
-  const paidFromAlice = initialAliceAmount - finalAliceAmount;
+  const paidToBob = BigInt(finalBobAmount!) - BigInt(initialBobAmount!);
+  const paidFromAlice = BigInt(initialAliceAmount!) - BigInt(finalAliceAmount!);
 
   if (paidToBob !== paidFromAlice) {
     throw new Error(`final outcome is not balanced: Alice paid ${paidFromAlice}, Bob received ${paidToBob}`);
@@ -213,7 +213,7 @@ export class Objective implements ObjectiveInterface {
     request: ObjectiveRequest,
     preApprove: boolean,
     myAddress: Address,
-    largestPaymentAmount: bigint,
+    largestPaymentAmount: bigint | undefined,
     getChannel: GetChannelByIdFunction,
     getConsensusChannel: GetTwoPartyConsensusLedgerFunction,
   ): Objective {
@@ -374,8 +374,8 @@ export class Objective implements ObjectiveInterface {
     // Since Alice is responsible for issuing vouchers she always has the largest payment amount
     // This means she can just set her FinalOutcomeFromAlice based on the largest voucher amount she has sent
     const finalOutcome = this.initialOutcome().clone();
-    finalOutcome.allocations.value[0].amount -= this.minimumPaymentAmount;
-    finalOutcome.allocations.value[1].amount += this.minimumPaymentAmount;
+    finalOutcome.allocations.value[0].amount = BigInt(finalOutcome.allocations.value[0].amount!) - this.minimumPaymentAmount;
+    finalOutcome.allocations.value[1].amount = BigInt(finalOutcome.allocations.value[1].amount!) + this.minimumPaymentAmount;
     return finalOutcome;
   }
 

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -165,7 +165,7 @@ export class Objective implements ObjectiveInterface {
   // MinimumPaymentAmount is the latest payment amount we have received from Alice before starting defunding.
   // This is set by Bob so he can ensure he receives the latest amount from any vouchers he's received.
   // If this is not set then virtual defunding will accept any final outcome from Alice.
-  minimumPaymentAmount?: bigint;
+  minimumPaymentAmount?: bigint = undefined;
 
   v?: VirtualChannel;
 

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -90,7 +90,7 @@ export function validateFinalOutcome(
   initialOutcome: SingleAssetExit,
   finalOutcome: SingleAssetExit,
   me: Address,
-  minAmount: bigint,
+  minAmount?: bigint,
 ): void {
   // Check the outcome participants are correct
   const alice = vFixed.participants[0];
@@ -117,7 +117,7 @@ export function validateFinalOutcome(
 
   // if we're Bob we want to make sure the final state Alice sent is equal to or larger than the payment we already have
   if (me === bob) {
-    if (paidToBob < minAmount) {
+    if (paidToBob < BigInt(minAmount!)) {
       throw new Error(`payment amount ${paidToBob} is less than the minimum payment amount ${minAmount}`);
     }
   }
@@ -165,7 +165,7 @@ export class Objective implements ObjectiveInterface {
   // MinimumPaymentAmount is the latest payment amount we have received from Alice before starting defunding.
   // This is set by Bob so he can ensure he receives the latest amount from any vouchers he's received.
   // If this is not set then virtual defunding will accept any final outcome from Alice.
-  minimumPaymentAmount: bigint = BigInt(0);
+  minimumPaymentAmount?: bigint;
 
   v?: VirtualChannel;
 
@@ -309,11 +309,12 @@ export class Objective implements ObjectiveInterface {
     myAddress: Address,
     getChannel: GetChannelByIdFunction,
     getTwoPartyConsensusLedger: GetTwoPartyConsensusLedgerFunction,
-    latestVoucherAmount: bigint = BigInt(0),
+    latestVoucherAmount?: bigint,
   ): Objective {
-    // if latestVoucherAmount == nil {
-    //   latestVoucherAmount = big.NewInt(0)
-    // }
+    if (!latestVoucherAmount) {
+      // eslint-disable-next-line no-param-reassign
+      latestVoucherAmount = BigInt(0);
+    }
 
     let cId: Destination;
     let err: Error | undefined;
@@ -374,8 +375,8 @@ export class Objective implements ObjectiveInterface {
     // Since Alice is responsible for issuing vouchers she always has the largest payment amount
     // This means she can just set her FinalOutcomeFromAlice based on the largest voucher amount she has sent
     const finalOutcome = this.initialOutcome().clone();
-    finalOutcome.allocations.value[0].amount = BigInt(finalOutcome.allocations.value[0].amount!) - this.minimumPaymentAmount;
-    finalOutcome.allocations.value[1].amount = BigInt(finalOutcome.allocations.value[1].amount!) + this.minimumPaymentAmount;
+    finalOutcome.allocations.value[0].amount = BigInt(finalOutcome.allocations.value[0].amount!) - BigInt(this.minimumPaymentAmount!);
+    finalOutcome.allocations.value[1].amount = BigInt(finalOutcome.allocations.value[1].amount!) + BigInt(this.minimumPaymentAmount!);
     return finalOutcome;
   }
 

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -173,7 +173,7 @@ export class Connection {
     // We only expect a single asset type, and we want to know how much is to be
     // diverted for that asset type.
     // So, we loop through amountFunds and break after the first asset type ...
-    let amount: bigint = BigInt(0);
+    let amount: bigint | undefined;
 
     /* eslint-disable no-unreachable-loop */
     for (const [, val] of amountFunds.value) {
@@ -191,7 +191,7 @@ export class Connection {
   expectedProposal(): Proposal {
     const g = this.getExpectedGuarantee();
 
-    let leftAmount: bigint = BigInt(0);
+    let leftAmount: bigint | undefined;
 
     /* eslint-disable no-unreachable-loop */
     for (const [, val] of this.guaranteeInfo.leftAmount!.value) {
@@ -260,7 +260,7 @@ export class Objective implements ObjectiveInterface, ProposalReceiver {
     request: ObjectiveRequest,
     preApprove: boolean,
     myAddress: Address,
-    chainId: bigint,
+    chainId: bigint | undefined,
     getTwoPartyConsensusLedger: GetTwoPartyConsensusLedgerFunction,
   ): Objective {
     let toMyRight: string;
@@ -885,7 +885,7 @@ export class ObjectiveRequest implements ObjectiveRequestInterface {
   }
 
   // Id returns the objective id for the request.
-  id(myAddress: Address, chainId: bigint): ObjectiveId {
+  id(myAddress: Address, chainId?: bigint): ObjectiveId {
     const idStr = this.channelId(myAddress).string();
     return `${ObjectivePrefix}${idStr}`;
   }

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -360,8 +360,8 @@ export class Objective implements ObjectiveInterface, ProposalReceiver {
       if (!init.b0.value.has(asset)) {
         init.b0.value.set(asset, BigInt(0));
       }
-      init.a0.value.set(asset, init.a0.value.get(asset)! + amount0);
-      init.b0.value.set(asset, init.b0.value.get(asset)! + amount1);
+      init.a0.value.set(asset, BigInt(init.a0.value.get(asset)!) + BigInt(amount0!));
+      init.b0.value.set(asset, BigInt(init.b0.value.get(asset)!) + BigInt(amount1!));
     }
 
     // Setup Ledger Channel Connections and expected guarantees

--- a/packages/nitro-util/src/json.ts
+++ b/packages/nitro-util/src/json.ts
@@ -39,7 +39,7 @@ function decodeValue(fieldType: FieldDescription, fieldJsonValue: any): any {
     }
 
     case 'bigint': {
-      return BigInt(fieldJsonValue);
+      return fieldJsonValue === null ? undefined : BigInt(fieldJsonValue);
     }
 
     case 'uint64': {
@@ -188,10 +188,9 @@ function encodeValue(fieldType: FieldDescription, fieldValue: any): any {
       return encodeArray(fieldType.value as FieldDescription, fieldValue);
     }
 
-    // TODO: Handle nil pointer case
-    // case 'bigint': {
-    //   return fieldValue;
-    // }
+    case 'bigint': {
+      return fieldValue === undefined ? null : fieldValue;
+    }
 
     case 'buffer': {
       // Marshall buffer as a base64 string

--- a/packages/nitro-util/src/json.ts
+++ b/packages/nitro-util/src/json.ts
@@ -47,8 +47,7 @@ function decodeValue(fieldType: FieldDescription, fieldJsonValue: any): any {
     }
 
     case 'buffer': {
-      const bufferValue = (fieldJsonValue === null) ? '' : fieldJsonValue;
-      return Buffer.from(bufferValue, 'base64');
+      return fieldJsonValue === null ? null : Buffer.from(fieldJsonValue, 'base64');
     }
 
     case 'object': {
@@ -194,7 +193,7 @@ function encodeValue(fieldType: FieldDescription, fieldValue: any): any {
 
     case 'buffer': {
       // Marshall buffer as a base64 string
-      return ((fieldValue as Buffer).length === 0) ? null : (fieldValue as Buffer).toString('base64');
+      return (fieldValue === null) ? null : (fieldValue as Buffer).toString('base64');
     }
 
     case 'address': {

--- a/packages/nitro-util/src/json.ts
+++ b/packages/nitro-util/src/json.ts
@@ -106,16 +106,18 @@ export function fromJSON(jsonEncodingMap: Record<string, any>, data: string, key
 
 // Go compatible JSON marshalling utility method
 export function toJSON(jsonEncodingMap: Record<string, any>, obj: any, keysMap: Map<string, string> = new Map()): any {
-  let jsonObj: any = { ...obj };
+  let mappedObj: any = { ...obj };
 
   // Replace object keys with mapped & capitalized keys
-  jsonObj = _.mapKeys(jsonObj, (value, key) => capitalizeFirstLetter(keysMap.get(key) ?? key));
+  mappedObj = _.mapKeys(mappedObj, (value, key) => capitalizeFirstLetter(keysMap.get(key) ?? key));
 
+  // Create a new object having keys in order of jsonEncodingMap keys
+  const jsonObj: any = {};
   Object.keys(jsonEncodingMap).forEach((fieldKey) => {
     const fieldType = jsonEncodingMap[fieldKey];
     const capitalizedFieldKey = capitalizeFirstLetter(fieldKey);
 
-    jsonObj[capitalizedFieldKey] = encodeValue(fieldType, jsonObj[capitalizedFieldKey]);
+    jsonObj[capitalizedFieldKey] = encodeValue(fieldType, mappedObj[capitalizedFieldKey]);
   });
 
   return jsonObj;

--- a/packages/util/src/test/utils.ts
+++ b/packages/util/src/test/utils.ts
@@ -1,5 +1,3 @@
-import { Buffer } from 'buffer';
-
 import {
   Allocation, Destination, Exit, SingleAssetExit, AllocationType, Allocations,
 } from '@cerc-io/nitro-client';
@@ -38,20 +36,20 @@ export function createOutcome(
       asset,
       assetMetadata: {
         assetType: 0,
-        metadata: Buffer.alloc(0),
+        metadata: null,
       },
       allocations: new Allocations([
         new Allocation({
           destination: Destination.addressToDestination(convertAddressToBytes32(alpha)),
           amount: BigInt(amount),
           allocationType: AllocationType.NormalAllocationType,
-          metadata: Buffer.alloc(0),
+          metadata: null,
         }),
         new Allocation({
           destination: Destination.addressToDestination(convertAddressToBytes32(beta)),
           amount: BigInt(amount),
           allocationType: AllocationType.NormalAllocationType,
-          metadata: Buffer.alloc(0),
+          metadata: null,
         }),
       ]),
     }),


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Use serialization map to get desired order of keys in resulting JSON
- Make `bigint` fields optional with `undefined` default value (corresponding to `nil` pointer in Go)
- Make byte slice fields optional with `null` default value (corresponding to `nil` slice value in Go)
- Update serialization for the cases above to match that in Go
