### PR TITLE
Use test actors in readme in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Run relay node using v2 watcher
 
 * In the first repo which is for NodeJS client
 
-  * Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`):
+  * Run a client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
 
     ```bash
     cd packages/server
 
     # In packages/server
-    yarn start -p 3006 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+    yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
     # Expected output:
     # ts-nitro:engine Constructed Engine +0ms
@@ -67,14 +67,14 @@ Run relay node using v2 watcher
 
   * Refresh the app for enabling logs
 
-  * Call method `setupClient('erin')`
+  * Call method `setupClient('charlie')`
 
   * Wait for `New peer found` log in console
 
-  * Call method `nitro.directFund` with address of client Alice and amount to be allocated
+  * Call method `nitro.directFund` with address of client Bob and amount to be allocated
 
     ```
-    nitro.directFund('0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE', 1_000_000)
+    nitro.directFund('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94', 1_000_000)
     ```
 
     Final expected log
@@ -84,10 +84,10 @@ Run relay node using v2 watcher
     Ledger channel created with id 0x841b8725d82bdbd67650b101183143dcccf29083e0b127ca90f0f8f81cfd8978
     ```
 
-  * Call method `nitro.virtualFund` with address of client Alice and amount to be allocated
+  * Call method `nitro.virtualFund` with address of client Bob and amount to be allocated
 
     ```
-    nitro.virtualFund('0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE', 1_000)
+    nitro.virtualFund('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94', 1_000)
     ```
 
     Final expected log

--- a/packages/example-web-app/README.md
+++ b/packages/example-web-app/README.md
@@ -46,6 +46,7 @@ Instructions to run two instances of `ts-nitro` clients in a browser environment
 
   yarn start
   ```
+
 ### Run
 
 * Open [app](http://localhost:3000) in 2 different browsers
@@ -104,6 +105,10 @@ Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and
 
 ### Run
 
+* Open [app](http://localhost:3000) in browser
+* Open console in browser inspect and enable debug logs by setting `localStorage.debug = 'ts-nitro:*'`
+* Refresh the app for enabling logs
+* Call method `setupClient('david')`
 * Run a `go-nitro` client for Erin (`0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01`):
 
   ```bash
@@ -120,14 +125,6 @@ Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and
   # Initializing websocket RPC transport...
   # Nitro as a Service listening on port 4006
   ```
-
-* Open [app](http://localhost:3000) in browser
-
-* Open console in browser inspect and enable debug logs by setting `localStorage.debug = 'ts-nitro:*'`
-
-* Refresh the app for enabling logs
-
-* Call method `setupClient('david')`
 
 * Call method `nitro.addPeerByMultiaddr` to connect to client Erin
 

--- a/packages/example-web-app/README.md
+++ b/packages/example-web-app/README.md
@@ -54,16 +54,16 @@ Instructions to run two instances of `ts-nitro` clients in a browser environment
 
 * Refresh the apps for enabling logs
 
-* Call methods `setupClient('erin')` and `setupClient('charlie')` separately in the 2 browsers
+* Call methods `setupClient('charlie')` and `setupClient('david')` separately in the 2 browsers
 
 * Wait for `New peer found` log in console
 
 * Call method `nitro.directFund` with address of the other browser client and amount to be allocated
 
-  * For example, call `nitro.directFund` in Erin browser with Charlie's address
+  * For example, call `nitro.directFund` in Charlie's browser with David's address
 
     ```
-    nitro.directFund('0x67D5b55604d1aF90074FcB69b8C51838FFF84f8d', 1_000_000)
+    nitro.directFund('0x111A00868581f73AB42FEEF67D235Ca09ca1E8db', 1_000_000)
     ```
 
   * Final expected log
@@ -75,10 +75,10 @@ Instructions to run two instances of `ts-nitro` clients in a browser environment
 
 * Call method `nitro.virtualFund` with address of the other browser client and amount to be allocated
 
-  * Call `nitro.virtualFund` in Erin browser with Charlie's address
+  * Call `nitro.virtualFund` in Charlie's browser with David's address
 
     ```
-    nitro.virtualFund('0x67D5b55604d1aF90074FcB69b8C51838FFF84f8d', 1_000)
+    nitro.virtualFund('0x111A00868581f73AB42FEEF67D235Ca09ca1E8db', 1_000)
     ```
 
   * Final expected log
@@ -104,11 +104,11 @@ Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and
 
 ### Run
 
-* Run a `go-nitro` client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
+* Run a `go-nitro` client for Erin (`0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01`):
 
   ```bash
   # In statechannels/go-nitro
-  go run . -msgport 3006 -wsmsgport 5006 -rpcport 4006 -pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 -chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d -naaddress 0x5FbDB2315678afecb367f032d93F642f64180aa3 -vpaaddress 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 -caaddress 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+  go run . -msgport 3006 -wsmsgport 5006 -rpcport 4006 -pk 0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2 -chainpk 7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6 -naaddress 0x5FbDB2315678afecb367f032d93F642f64180aa3 -vpaaddress 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 -caaddress 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 
   # Expected output:
   # Initialising mem store...
@@ -127,18 +127,18 @@ Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and
 
 * Refresh the app for enabling logs
 
-* Call method `setupClient('erin')`
+* Call method `setupClient('david')`
 
-* Call method `nitro.addPeerByMultiaddr` to connect to client Bob
-
-  ```
-  nitro.addPeerByMultiaddr('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94', '/ip4/127.0.0.1/tcp/5006/ws/p2p/16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes')
-  ```
-
-* Call method `nitro.directFund` with address of client Bob and amount to be allocated
+* Call method `nitro.addPeerByMultiaddr` to connect to client Erin
 
   ```
-  nitro.directFund('0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94', 1_000_000)
+  nitro.addPeerByMultiaddr('0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01', '/ip4/127.0.0.1/tcp/5006/ws/p2p/16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes')
+  ```
+
+* Call method `nitro.directFund` with address of client Erin and amount to be allocated
+
+  ```
+  nitro.directFund('0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01', 1_000_000)
   ```
 
 * Final expected log

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -41,22 +41,22 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
 ### Run
 
-* Run a client for David (`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`):
+* Run a client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
 
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781 --chainpk 5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a --durable-store ./david-db
+  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./david-db
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms
   ```
 
-* Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) and pass in David's address as a counterparty to create channels with:
+* Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) and pass in Bob's address as a counterparty to create channels with:
 
   ```bash
   # In packages/server
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --durable-store ./alice-db --counterparty 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db --direct-fund --virtual-fund --pay 50 --virtual-defund --direct-defund
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 --direct-fund --virtual-fund --pay 50 --virtual-defund --direct-defund
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -71,7 +71,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # ts-nitro:server Virtual payment channel created with id 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
   # .
   # .
-  # ts-nitro:engine Sending message: {"to":"0x111A00","from":"0xAAA662","payloadSummaries":[],"proposalSummaries":[],"payments":[{"amount":50,"channelId":"0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa"}],"rejectedObjectives":[]} +8ms
+  # ts-nitro:engine Sending message: {"to":"0xBBB676","from":"0xAAA662","payloadSummaries":[],"proposalSummaries":[],"payments":[{"amount":50,"channelId":"0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa"}],"rejectedObjectives":[]} +8ms
   # .
   # .
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -41,12 +41,6 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
 ### Run
 
-* In `nodejs-ts-nitro` repo change directory to `packages/server`
-
-    ```bash
-    cd packages/server
-    ```
-
 * Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`):
 
   ```bash

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -41,22 +41,27 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
 ### Run
 
-* Run a client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
+* In `nodejs-ts-nitro` repo change directory to `packages/server`
+
+    ```bash
+    cd packages/server
+    ```
+
+* Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`):
 
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./david-db
-
+  yarn start -p 3006 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms
   ```
 
-* Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) and pass in Bob's address as a counterparty to create channels with:
+* Run another client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`) and pass in Alice's address as a counterparty to create the ledger channel with:
 
   ```bash
   # In packages/server
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 --direct-fund --virtual-fund --pay 50 --virtual-defund --direct-defund
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --counterparty 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE --direct-fund
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -71,7 +76,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # ts-nitro:server Virtual payment channel created with id 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
   # .
   # .
-  # ts-nitro:engine Sending message: {"to":"0xBBB676","from":"0xAAA662","payloadSummaries":[],"proposalSummaries":[],"payments":[{"amount":50,"channelId":"0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa"}],"rejectedObjectives":[]} +8ms
+  # ts-nitro:engine Sending message: {"to":"0xAAA662","from":"0xBBB676","payloadSummaries":[],"proposalSummaries":[],"payments":[{"amount":50,"channelId":"0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa"}],"rejectedObjectives":[]} +8ms
   # .
   # .
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms
@@ -98,11 +103,11 @@ Instructions to run instances of `ts-nitro` (node) and `go-nitro` clients and cr
 
 ### Run
 
-* Run a `go-nitro` client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`):
+* Run a `go-nitro` client for Erin (`0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01`):
 
   ```bash
   # In statechannels/go-nitro
-  go run . -msgport 3006 -rpcport 4006 -pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 -chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d -naaddress 0x5FbDB2315678afecb367f032d93F642f64180aa3 -vpaaddress 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 -caaddress 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+  go run . -msgport 3006 -rpcport 4006 -pk 0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2 -chainpk 7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6 -naaddress 0x5FbDB2315678afecb367f032d93F642f64180aa3 -vpaaddress 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 -caaddress 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 
   # Expected output:
   # Initialising mem store...
@@ -119,7 +124,7 @@ Instructions to run instances of `ts-nitro` (node) and `go-nitro` clients and cr
 
   ```bash
   # In ts-nitro/packages/server
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 --cp-peer-id 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes --cp-port 3006 --direct-fund
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --counterparty 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01 --cp-peer-id 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes --cp-port 3006 --direct-fund
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -102,7 +102,7 @@ const main = async () => {
 
   const msgService = await createP2PMessageService(process.env.RELAY_MULTIADDR, argv.port, store.getAddress());
 
-  const [client] = await setupClient(
+  const client = await setupClient(
     msgService,
     store,
     {

--- a/packages/server/test-e2e/integration.test.ts
+++ b/packages/server/test-e2e/integration.test.ts
@@ -26,44 +26,48 @@ import { getMetricsKey, getMetricsMessageObj, getMetricsMessage } from './utils'
 describe('test Client', () => {
   let aliceClient: Client;
   let bobClient: Client;
-  let metricsAlice: Metrics;
-  let metricsBob: Metrics;
+  let aliceMetrics: Metrics;
+  let bobMetrics: Metrics;
 
   it('should instantiate Clients', async () => {
     assert(process.env.RELAY_MULTIADDR, 'RELAY_MULTIADDR should be set in .env');
 
     const aliceStore = new MemStore(hex2Bytes(ACTORS.alice.privateKey));
     const aliceMsgService = await createP2PMessageService(process.env.RELAY_MULTIADDR, ALICE_MESSAGING_PORT, aliceStore.getAddress());
+    aliceMetrics = new Metrics();
 
-    [aliceClient, metricsAlice] = await setupClient(
+    aliceClient = await setupClient(
       aliceMsgService,
       aliceStore,
       {
         chainPk: ACTORS.alice.chainPrivateKey,
         chainURL: DEFAULT_CHAIN_URL,
       },
+      aliceMetrics,
     );
 
     expect(aliceClient.address).to.equal(ACTORS.alice.address);
 
     const bobStore = new MemStore(hex2Bytes(ACTORS.bob.privateKey));
     const bobMsgService = await createP2PMessageService(process.env.RELAY_MULTIADDR, BOB_MESSAGING_PORT, bobStore.getAddress());
+    bobMetrics = new Metrics();
 
-    [bobClient, metricsBob] = await setupClient(
+    bobClient = await setupClient(
       bobMsgService,
       bobStore,
       {
         chainPk: ACTORS.bob.chainPrivateKey,
         chainURL: DEFAULT_CHAIN_URL,
       },
+      bobMetrics,
     );
 
     expect(bobClient.address).to.equal(ACTORS.bob.address);
 
     await waitForPeerInfoExchange(1, [aliceMsgService, bobMsgService]);
 
-    expect(metricsAlice.getMetrics()).to.have.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.alice.address));
-    expect(metricsBob.getMetrics()).to.have.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.bob.address));
+    expect(aliceMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.alice.address));
+    expect(bobMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.bob.address));
   });
 
   it('should create ledger channel', async () => {
@@ -99,24 +103,24 @@ describe('test Client', () => {
     // Check that channelId value is present as a substring in id
     expect(response.id).to.contain(response.channelId.value);
 
-    expect(metricsAlice.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.alice.address, ACTORS.bob.address));
-    expect(metricsBob.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.bob.address, ACTORS.alice.address));
+    expect(aliceMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.alice.address, ACTORS.bob.address));
+    expect(bobMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.bob.address, ACTORS.alice.address));
 
-    expect(metricsAlice.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.alice.address, ACTORS.bob.address));
-    expect(metricsBob.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.bob.address, ACTORS.alice.address));
+    expect(aliceMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.alice.address, ACTORS.bob.address));
+    expect(bobMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.bob.address, ACTORS.alice.address));
 
-    expect(metricsAlice.getMetrics()).to.include.keys(...getMetricsKey(METRICS_KEYS_DIRECT_FUND, ACTORS.alice.address));
+    expect(aliceMetrics.getMetrics()).to.include.keys(...getMetricsKey(METRICS_KEYS_DIRECT_FUND, ACTORS.alice.address));
 
     getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.alice.address).forEach((key) => {
-      expect(metricsAlice.getMetrics()[key]).to.be.above(0);
+      expect(aliceMetrics.getMetrics()[key]).to.be.above(0);
     });
 
     getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.bob.address).forEach((key) => {
-      expect(metricsBob.getMetrics()[key]).to.be.above(0);
+      expect(bobMetrics.getMetrics()[key]).to.be.above(0);
     });
 
-    expect(metricsAlice.getMetrics()[getMetricsKey(['handleObjectiveRequest'], ACTORS.alice.address)[0]]).to.be.above(0);
-    expect(metricsBob.getMetrics()[getMetricsKey(['constructObjectiveFromMessage'], ACTORS.bob.address)[0]]).to.be.above(0);
+    expect(aliceMetrics.getMetrics()[getMetricsKey(['handleObjectiveRequest'], ACTORS.alice.address)[0]]).to.be.above(0);
+    expect(bobMetrics.getMetrics()[getMetricsKey(['constructObjectiveFromMessage'], ACTORS.bob.address)[0]]).to.be.above(0);
 
     // TODO: Implement and close services
     // client.close();

--- a/packages/util/src/helpers.ts
+++ b/packages/util/src/helpers.ts
@@ -33,13 +33,12 @@ export async function setupClient(
     chainPk: string,
     chainURL: string
   },
-): Promise<[Client, Metrics]> {
+  metricsApi?: Metrics,
+): Promise<Client> {
   const {
     chainPk,
     chainURL,
   } = options;
-
-  const metricsApi = new Metrics();
 
   const chainService = await EthChainService.newEthChainService(
     chainURL,
@@ -58,7 +57,7 @@ export async function setupClient(
     metricsApi,
   );
 
-  return [client, metricsApi];
+  return client;
 }
 
 /**

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -58,7 +58,7 @@ export class Nitro {
 
     const msgService = await createP2PMessageService(relayMultiaddr, store.getAddress());
 
-    const [client] = await setupClient(
+    const client = await setupClient(
       msgService,
       store,
       {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Pass `metricsApi` to `setupClient` as an optional param
- Use test actors in alphabetical order