### PR TITLE
Run nitro commands in CLI individually and add remaining in browser app

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Run relay node using v2 watcher
     cd packages/server
 
     # In packages/server
-    yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    yarn cli -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
     # Expected output:
     # ts-nitro:engine Constructed Engine +0ms
@@ -67,7 +67,10 @@ Run relay node using v2 watcher
 
   * Refresh the app for enabling logs
 
-  * Call method `setupClient('charlie')`
+  * Setup client
+    ```
+    const nitro = await setupClient('charlie')
+    ```
 
   * Wait for `New peer found` log in console
 

--- a/packages/example-web-app/README.md
+++ b/packages/example-web-app/README.md
@@ -55,7 +55,15 @@ Instructions to run two instances of `ts-nitro` clients in a browser environment
 
 * Refresh the apps for enabling logs
 
-* Call methods `setupClient('charlie')` and `setupClient('david')` separately in the 2 browsers
+* Setup clients
+  * In first browser
+    ```
+    const nitro = await setupClient('charlie')
+    ```
+  * In second browser
+    ```
+    const nitro = await setupClient('david')
+    ```
 
 * Wait for `New peer found` log in console
 
@@ -108,7 +116,10 @@ Instructions to run instances of `ts-nitro` (browser) and `go-nitro` clients and
 * Open [app](http://localhost:3000) in browser
 * Open console in browser inspect and enable debug logs by setting `localStorage.debug = 'ts-nitro:*'`
 * Refresh the app for enabling logs
-* Call method `setupClient('david')`
+* Setup client
+  ```
+  const nitro = await setupClient('david')
+  ```
 * Run a `go-nitro` client for Erin (`0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01`):
 
   ```bash

--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -39,7 +39,7 @@ function App () {
     window.onunhandledrejection = (err) => {
       // Log unhandled errors instead of stopping application
       console.log(err);
-    }
+    };
   }, []);
 
   return (

--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_CHAIN_URL,
   Nitro
 } from '@cerc-io/util';
+import { JSONbigNative } from '@cerc-io/nitro-util';
 
 import logo from './logo.svg';
 import './App.css';
@@ -14,6 +15,7 @@ declare global {
   interface Window {
     setupClient: (name: string) => Promise<Nitro>
     clearClientStorage: () => Promise<boolean>
+    out: (jsonObject: any) => void
   }
 }
 
@@ -32,6 +34,10 @@ window.setupClient = async (name: string): Promise<Nitro> => {
     process.env.REACT_APP_RELAY_MULTIADDR,
     `${name}-db`
   );
+};
+
+window.out = (jsonObject) => {
+  console.log(JSONbigNative.stringify(jsonObject, null, 2));
 };
 
 function App () {

--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import assert from 'assert';
 
-import { test } from '@cerc-io/nitro-client';
 import {
   ACTORS,
   DEFAULT_CHAIN_URL,
@@ -13,21 +12,20 @@ import './App.css';
 
 declare global {
   interface Window {
-    nitro?: Nitro
-    setupClient: (name: string) => Promise<void>
-    clearClientStorage: () => Promise<void>
+    setupClient: (name: string) => Promise<Nitro>
+    clearClientStorage: () => Promise<boolean>
   }
 }
 
 window.clearClientStorage = Nitro.clearClientStorage;
 
 // Method to setup nitro client with test actors
-window.setupClient = async (name: string) => {
+window.setupClient = async (name: string): Promise<Nitro> => {
   const actor = ACTORS[name];
   assert(actor, `Actor with name ${name} does not exists`);
   assert(process.env.REACT_APP_RELAY_MULTIADDR);
 
-  window.nitro = await Nitro.setupClient(
+  return Nitro.setupClient(
     actor.privateKey,
     DEFAULT_CHAIN_URL,
     actor.chainPrivateKey,
@@ -37,18 +35,17 @@ window.setupClient = async (name: string) => {
 };
 
 function App () {
-  const [data, setData] = useState('');
-
   useEffect(() => {
-    const res = test();
-    setData(res);
+    window.onunhandledrejection = (err) => {
+      // Log unhandled errors instead of stopping application
+      console.log(err);
+    }
   }, []);
 
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <p>{data}</p>
       </header>
     </div>
   );

--- a/packages/nitro-client/src/browser.ts
+++ b/packages/nitro-client/src/browser.ts
@@ -9,6 +9,7 @@ export { SingleAssetExit, Exit } from './channel/state/outcome/exit';
 export { Allocation, AllocationType, Allocations } from './channel/state/outcome/allocation';
 export { Destination } from './types/destination';
 export { Metrics, GetMetrics } from './client/engine/metrics';
+export { LedgerChannelInfo, PaymentChannelInfo } from './client/query/types';
 
 export const test = (): string => {
   // eslint-disable-next-line no-console

--- a/packages/nitro-client/src/client/client.ts
+++ b/packages/nitro-client/src/client/client.ts
@@ -252,6 +252,11 @@ export class Client {
     return d;
   }
 
+  // Close stops the client from responding to any input.
+  // TODO: Implement
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async close(): Promise<void> {}
+
   // GetLedgerChannel returns the ledger channel with the given id.
   // If no ledger channel exists with the given id an error is returned.
   async getLedgerChannel(id: Destination): Promise<LedgerChannelInfo> {

--- a/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
+++ b/packages/nitro-client/src/client/engine/chainservice/adjudicator/typeconversions.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 import { Allocations } from '../../../../channel/state/outcome/allocation';
 import { AssetMetadata, Exit } from '../../../../channel/state/outcome/exit';
 import { FixedPart, VariablePart } from '../../../../channel/state/state';

--- a/packages/nitro-client/src/client/engine/messageservice/messageservice.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/messageservice.ts
@@ -15,5 +15,5 @@ export interface MessageService {
 
   // Close closes the message service
   // TODO: Can throw an error
-  close (): void;
+  close (): Promise<void>;
 }

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
@@ -25,7 +25,7 @@ export class P2PMessageService implements MessageService {
   static async newMessageService(
     relayMultiAddr: string,
     me: Address,
-    pk: Uint8Array,
+    pk: Buffer,
     logWriter?: WritableStream,
   ): Promise<P2PMessageService> {
     const baseP2PMessageService = await BaseP2PMessageService.newMessageService(

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
@@ -59,7 +59,7 @@ export class P2PMessageService implements MessageService {
   }
 
   // Closes the P2PMessageService
-  close(): void {
+  close(): Promise<void> {
     return this.baseP2PMessageService.close();
   }
 

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.browser.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 import type { ReadChannel } from '@cerc-io/ts-channel';
 // @ts-expect-error
 import type { PeerId } from '@libp2p/interface-peer-id';

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import assert from 'assert';
 
 import type { ReadChannel } from '@cerc-io/ts-channel';

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
@@ -42,7 +42,7 @@ export class P2PMessageService implements MessageService {
     ip: string,
     port: number,
     me: Address,
-    pk: Uint8Array,
+    pk: Buffer,
     useMdnsPeerDiscovery: boolean,
     logWriter?: WritableStream,
   ): Promise<P2PMessageService> {

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.node.ts
@@ -101,7 +101,7 @@ export class P2PMessageService implements MessageService {
   }
 
   // Closes the P2PMessageService
-  close(): void {
+  close(): Promise<void> {
     return this.baseP2PMessageService.close();
   }
 

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
@@ -37,6 +37,7 @@ const DELIMITER = '\n';
 const BUFFER_SIZE = 1_000;
 const NUM_CONNECT_ATTEMPTS = 20;
 const RETRY_SLEEP_DURATION = 5 * 1000; // milliseconds
+const ERR_CONNECTION_CLOSED = 'the connection is being closed';
 
 // BasicPeerInfo contains the basic information about a peer
 export interface BasicPeerInfo {
@@ -370,6 +371,11 @@ export class BaseP2PMessageService implements MessageService {
   // checkError panics if the message service is running and there is an error, otherwise it just returns
   // eslint-disable-next-line n/handle-callback-err
   private checkError(err: Error) {
+    if (err.message.includes(ERR_CONNECTION_CLOSED)) {
+      log('uncaughtException', err.message);
+      return;
+    }
+
     throw err;
   }
 

--- a/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-client/src/client/engine/messageservice/p2p-message-service/service.ts
@@ -377,11 +377,11 @@ export class BaseP2PMessageService implements MessageService {
   }
 
   // Closes the P2PMessageService
-  close(): void {
+  async close(): Promise<void> {
     assert(this.p2pHost);
 
-    this.p2pHost.unhandle(PROTOCOL_ID);
-    this.p2pHost.stop();
+    await this.p2pHost.unhandle(PROTOCOL_ID);
+    await this.p2pHost.stop();
   }
 
   // peerInfoReceived returns a channel that receives a PeerInfo when a peer is discovered

--- a/packages/nitro-client/src/client/engine/store/store.ts
+++ b/packages/nitro-client/src/client/engine/store/store.ts
@@ -56,7 +56,7 @@ export interface Store extends ConsensusChannelStore, VoucherStore {
   // The behavior of Close after the first call is undefined
   // TODO: Check for io.Closer alternative
   // TODO: Can throw an error
-  close (): void
+  close (): void | Promise<void>
 }
 
 export interface ConsensusChannelStore {

--- a/packages/nitro-client/src/node.ts
+++ b/packages/nitro-client/src/node.ts
@@ -9,3 +9,4 @@ export { SingleAssetExit, Exit } from './channel/state/outcome/exit';
 export { Allocation, AllocationType, Allocations } from './channel/state/outcome/allocation';
 export { Destination } from './types/destination';
 export { Metrics, GetMetrics } from './client/engine/metrics';
+export { LedgerChannelInfo, PaymentChannelInfo } from './client/query/types';

--- a/packages/nitro-client/src/payments/vouchers.ts
+++ b/packages/nitro-client/src/payments/vouchers.ts
@@ -10,6 +10,7 @@
 
 import { ethers } from 'ethers';
 import _ from 'lodash';
+import { Buffer } from 'buffer';
 
 import { Bytes32, Voucher as NitroVoucher } from '@statechannels/nitro-protocol';
 import {

--- a/packages/nitro-client/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-client/src/protocols/directdefund/directdefund.ts
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual';
 
 import Channel, { ReadWriteChannel } from '@cerc-io/ts-channel';
 import {
-  FieldDescription, Uint64, fromJSON, toJSON,
+  FieldDescription, JSONbigNative, Uint64, fromJSON, toJSON,
 } from '@cerc-io/nitro-util';
 
 import { Destination } from '../../types/destination';
@@ -283,7 +283,7 @@ export class Objective implements ObjectiveInterface {
         break;
       }
       default:
-        throw new Error(`objective ${updated} cannot handle event ${event}`);
+        throw new Error(`objective ${JSONbigNative.stringify(updated)} cannot handle event ${JSONbigNative.stringify(event)}`);
     }
 
     return updated;

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -338,7 +338,7 @@ export class Objective implements ObjectiveInterface {
 
     if (!(event instanceof DepositedEvent)) {
       // TODO: Handle partial return case if required
-      throw new Error(`objective ${updated} cannot handle event ${event}`);
+      throw new Error(`objective ${JSONbigNative.stringify(updated)} cannot handle event ${JSONbigNative.stringify(event)}`);
     }
 
     const de = event;

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 
 dist
+
+# DurableStore directory
+out

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -41,41 +41,38 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
 ### Run
 
-<!-- TODO: Pay from Alice to Bob -->
-
-* Run a client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) with `wait` flag to keep it running:
-
+* Run a client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`) with `wait` flag to keep it running:
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --wait
+  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db
+
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms
   ```
-
-* Run another client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`) and pass in Alice's address as a counterparty to create the ledger channel with:
-
+* Run another client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) and pass in Bob's address as a counterparty to create the ledger channel with:
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --direct-fund --counterparty 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
+  # In packages/server
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms
   # .
   # .
-  # ts-nitro:engine Objective DirectFunding-0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc is complete & returned to API +10ms
-  # ts-nitro:server Ledger channel created with id 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc
+  # ts-nitro:engine Objective DirectFunding-0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e is complete & returned to API +26ms
+  # ts-nitro:server Ledger channel created with id 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e
   ```
 
 * Run command to get ledger channel information
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --get-ledger-channel --ledger-channel 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-ledger-channel --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e
 
   # Expected output:
-  #   ts-nitro:server Ledger channel 0xc659e1bfdba882e256d590ecc032260e2c582c378a403d30818cfc0f1eafec3a status:
+  #   ts-nitro:server Ledger channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e status:
   # ts-nitro:server  {
-  #   "ID": "0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc",
+  #   "ID": "0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e",
   #   "Status": "Open",
   #   "Balance": {
   #     "AssetAddress": "0x0000000000000000000000000000000000000000",
@@ -90,7 +87,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run client for Bob again to create virtual payment channel:
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --virtual-fund --counterparty 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
 
   # Final Expected output:
   # ts-nitro:engine Objective VirtualFund-0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af is complete & returned to API +0ms
@@ -100,7 +97,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run command to get payment channel information
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --get-payment-channel --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-payment-channel --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
 
   # Expected output:
   # ts-nitro:server Virtual payment channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af status:
@@ -120,7 +117,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run client for Bob to make payment with virtual payment channel id from above:
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --pay 50 --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --pay 50 --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -150,7 +147,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close virtual payment channel using client Bob (Get channel id from `virtual-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --virtual-defund --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --get-payment-channel
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-defund --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --get-payment-channel
 
   # Final Expected output:
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms
@@ -160,11 +157,11 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close the ledger channel using client Bob (Get channel id from `direct-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --direct-defund --ledger-channel 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc --get-ledger-channel
+  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-defund --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e --get-ledger-channel
 
   # Final Expected output:
-  # ts-nitro:engine Objective DirectDefunding-0x49ee60de0e1beebdf6070690cde0f66c86d576a6b2721001e6f7b0eaa11b3223 is complete & returned to API +1ms
-  # ts-nitro:server Ledger channel with id 0x49ee60de0e1beebdf6070690cde0f66c86d576a6b2721001e6f7b0eaa11b3223 closed
+  # ts-nitro:engine Objective DirectDefunding-0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e is complete & returned to API +1ms
+  # ts-nitro:server Ledger channel with id 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e closed
   ```
 
   <!-- TODO: Check balance on chain -->

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -45,7 +45,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db
+  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --wait
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -155,6 +155,18 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # Final Expected output:
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms
   # ts-nitro:server Virtual payment channel with id 0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa closed
+  # ts-nitro:server Virtual payment channel 0x78d563cf7e92b55c4086efa0424d4b1fdf71cfe06ad1fc79371924655d929637 status:
+  # ts-nitro:server  {
+  # "ID": "0x78d563cf7e92b55c4086efa0424d4b1fdf71cfe06ad1fc79371924655d929637",
+  # "Status": "Complete",
+  # "Balance": {
+  #   "AssetAddress": "0x0000000000000000000000000000000000000000",
+  #   "Payee": "0xbbb676f9cff8d242e9eac39d063848807d3d1d94",
+  #   "Payer": "0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce",
+  #   "PaidSoFar": 125,
+  #   "RemainingFunds": 875
+  # }
+  # } +4ms
   ```
 
 * Close the ledger channel using client Bob (Get channel id from `direct-fund` logs)
@@ -165,6 +177,18 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # Final Expected output:
   # ts-nitro:engine Objective DirectDefunding-0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e is complete & returned to API +1ms
   # ts-nitro:server Ledger channel with id 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e closed
+  # ts-nitro:server Ledger channel 0xa7cb480e3f8252735e937e19683098295a1fab85609dfa04098bff3df71c4082 status:
+  # ts-nitro:server  {
+  # "ID": "0xa7cb480e3f8252735e937e19683098295a1fab85609dfa04098bff3df71c4082",
+  # "Status": "Complete",
+  # "Balance": {
+  #   "AssetAddress": "0x0000000000000000000000000000000000000000",
+  #   "Hub": "0xbbb676f9cff8d242e9eac39d063848807d3d1d94",
+  #   "Client": "0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce",
+  #   "HubBalance": 1000125,
+  #   "ClientBalance": 999875
+  # }
+  # } +3ms
   ```
 
   <!-- TODO: Check balance on chain -->

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -45,7 +45,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --wait
+  yarn cli -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --wait
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -56,7 +56,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
   ```bash
   # In packages/server
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -70,7 +70,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run command to get ledger channel information
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-ledger-channel --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-ledger-channel --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e
 
   # Expected output:
   #   ts-nitro:server Ledger channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e status:
@@ -90,7 +90,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run client for Bob again to create virtual payment channel:
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
 
   # Final Expected output:
   # ts-nitro:engine Objective VirtualFund-0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af is complete & returned to API +0ms
@@ -100,7 +100,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run command to get payment channel information
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-payment-channel --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --get-payment-channel --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
 
   # Expected output:
   # ts-nitro:server Virtual payment channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af status:
@@ -120,7 +120,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Run client for Bob to make payment with virtual payment channel id from above:
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --pay 50 --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --pay --amount 50 --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -150,7 +150,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close virtual payment channel using client Bob (Get channel id from `virtual-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-defund --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --get-payment-channel
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --virtual-defund --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --get-payment-channel
 
   # Final Expected output:
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms
@@ -172,7 +172,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close the ledger channel using client Bob (Get channel id from `direct-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-defund --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e --get-ledger-channel
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-defund --ledger-channel 0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e --get-ledger-channel
 
   # Final Expected output:
   # ts-nitro:engine Objective DirectDefunding-0xe29e2d7ee060fb78b279ac4c8f5cc9bf59334f3e0d25315d5e3c822ed0303d9e is complete & returned to API +1ms
@@ -238,7 +238,7 @@ Instructions to run instances of `ts-nitro` (node) and `go-nitro` clients and cr
 
   ```bash
   # In ts-nitro/packages/server
-  yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --counterparty 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01 --cp-peer-id 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes --cp-port 3006 --direct-fund
+  yarn cli -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --counterparty 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01 --cp-peer-id 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes --cp-port 3006 --direct-fund
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -45,7 +45,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 
   ```bash
   # In packages/server
-  yarn start -p 3006 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db
+  yarn start -p 3006 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --wait
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -42,6 +42,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 ### Run
 
 * Run a client for Bob (`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`) with `wait` flag to keep it running:
+
   ```bash
   # In packages/server
   yarn start -p 3006 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db
@@ -50,7 +51,9 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # ts-nitro:engine Constructed Engine +0ms
   # ts-nitro:server Started P2PMessageService +0ms
   ```
+
 * Run another client for Alice (`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`) and pass in Bob's address as a counterparty to create the ledger channel with:
+
   ```bash
   # In packages/server
   yarn start -p 3005 --pk 2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d --chainpk ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --store ./alice-db --direct-fund --counterparty 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -67,7 +67,25 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # ts-nitro:server Ledger channel created with id 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc
   ```
 
-  <!-- TODO: getLedgerChannel -->
+* Run command to get ledger channel information
+
+  ```bash
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --get-ledger-channel --ledger-channel 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc
+
+  # Expected output:
+  #   ts-nitro:server Ledger channel 0xc659e1bfdba882e256d590ecc032260e2c582c378a403d30818cfc0f1eafec3a status:
+  # ts-nitro:server  {
+  #   "ID": "0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc",
+  #   "Status": "Open",
+  #   "Balance": {
+  #     "AssetAddress": "0x0000000000000000000000000000000000000000",
+  #     "Hub": "0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce",
+  #     "Client": "0xbbb676f9cff8d242e9eac39d063848807d3d1d94",
+  #     "HubBalance": 1000000,
+  #     "ClientBalance": 1000000
+  #   }
+  #   } +2ms
+  ```
 
 * Run client for Bob again to create virtual payment channel:
 
@@ -79,12 +97,30 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
   # ts-nitro:server Virtual payment channel created with id 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
   ```
 
-  <!-- TODO: getPaymentChannel -->
+* Run command to get payment channel information
+
+  ```bash
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --get-payment-channel --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
+
+  # Expected output:
+  # ts-nitro:server Virtual payment channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af status:
+  # ts-nitro:server  {
+  #   "ID": "0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af",
+  #   "Status": "Open",
+  #   "Balance": {
+  #     "AssetAddress": "0x0000000000000000000000000000000000000000",
+  #     "Payee": "0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce",
+  #     "Payer": "0xbbb676f9cff8d242e9eac39d063848807d3d1d94",
+  #     "PaidSoFar": 0,
+  #     "RemainingFunds": 1000
+  #   }
+  # } +1ms
+  ```
 
 * Run client for Bob to make payment with virtual payment channel id from above:
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --pay 50 --virtual-payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --pay 50 --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --wait
 
   # Expected output:
   # ts-nitro:engine Constructed Engine +0ms
@@ -114,7 +150,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close virtual payment channel using client Bob (Get channel id from `virtual-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --virtual-defund --virtual-payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --virtual-defund --payment-channel 0x8b0275a133addd8df2eafc84f2283ddf560a6c75eaafa1709e1f513bee5787af --get-payment-channel
 
   # Final Expected output:
   # ts-nitro:engine Objective VirtualDefund-0xe613b9f1651f971473061a968823463e9570b83230c2bce734b21800f663e4aa is complete & returned to API +1ms
@@ -124,7 +160,7 @@ Instructions to run two instances of `ts-nitro` clients in a node environment an
 * Close the ledger channel using client Bob (Get channel id from `direct-fund` logs)
 
   ```bash
-  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --direct-defund --ledger-channel 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc
+  yarn start -p 3005 --pk 0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4 --chainpk 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --store ./bob-db --direct-defund --ledger-channel 0xc47be3b1d43b90be058eaad3cd4f2250e4f9645792125011003bc548d33d2ebc --get-ledger-channel
 
   # Final Expected output:
   # ts-nitro:engine Objective DirectDefunding-0x49ee60de0e1beebdf6070690cde0f66c86d576a6b2721001e6f7b0eaa11b3223 is complete & returned to API +1ms

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "DEBUG=ts-nitro:* ts-node src/index.ts",
+    "cli": "DEBUG=ts-nitro:* ts-node src/index.ts",
     "lint": "eslint .",
     "test:e2e": "DEBUG=ts-nitro:* mocha test-e2e/**/*.test.ts --bail",
     "test:deploy-contracts": "DEBUG=ts-nitro:* yarn ts-node test-e2e/scripts/deploy-contracts.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,8 +81,12 @@ const getArgv = () => yargs.parserConfiguration({
     describe: 'Whether to get information about a virtual payment channel',
   },
   pay: {
+    type: 'boolean',
+    describe: 'Whether to pay on the virtual payment channel with the given counterparty',
+  },
+  amount: {
     type: 'number',
-    describe: 'Amount to pay on the virtual payment channel with the given counterparty',
+    describe: 'Amount for fund and pay methods',
   },
   virtualDefund: {
     type: 'boolean',
@@ -171,7 +175,7 @@ const main = async () => {
         asset,
         client.address,
         counterParty,
-        1_000_000,
+        argv.amount ?? 1_000_000,
       ),
       appDefinition: asset,
       appData: '0x00',
@@ -199,7 +203,7 @@ const main = async () => {
         asset,
         client.address,
         counterParty,
-        1_000,
+        argv.amount ?? 1_000,
       ),
       appDefinition: asset,
       nonce: Date.now(),
@@ -217,10 +221,10 @@ const main = async () => {
     paymentChannelIdString = virtualPaymentChannelResponse.channelId.string();
   }
 
-  if (argv.pay !== undefined) {
+  if (argv.pay) {
     assert(paymentChannelIdString, 'Provide payment-channel id for payment');
     const virtualPaymentChannelId = new Destination(paymentChannelIdString);
-    await client.pay(virtualPaymentChannelId, BigInt(argv.pay));
+    await client.pay(virtualPaymentChannelId, BigInt(argv.amount ?? 0));
 
     // TODO: Wait for the payment to be processed
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,8 @@ import { DirectFundParams, VirtualFundParams } from './types';
 
 const log = debug('ts-nitro:server');
 
+const ErrConnectionClosed = 'the connection is being closed';
+
 const getArgv = () => yargs.parserConfiguration({
   'parse-numbers': false,
 }).options({
@@ -290,5 +292,9 @@ main()
   });
 
 process.on('uncaughtException', (err) => {
+  if (err.message.includes(ErrConnectionClosed)) {
+    return;
+  }
+
   log('uncaughtException', err);
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,8 +20,6 @@ import { DirectFundParams, VirtualFundParams } from './types';
 
 const log = debug('ts-nitro:server');
 
-const ErrConnectionClosed = 'the connection is being closed';
-
 const getArgv = () => yargs.parserConfiguration({
   'parse-numbers': false,
 }).options({
@@ -292,10 +290,5 @@ main()
   });
 
 process.on('uncaughtException', (err) => {
-  if (err.message.includes(ErrConnectionClosed)) {
-    log('uncaughtException', err.message);
-    return;
-  }
-
   log('uncaughtException', err);
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,11 +8,12 @@ import {
   setupClient,
   createOutcome,
   DEFAULT_CHAIN_URL,
+  subscribeVoucherLogs,
 } from '@cerc-io/util';
 import {
   Destination, DurableStore, MemStore, Store,
 } from '@cerc-io/nitro-client';
-import { JSONbigNative, hex2Bytes, go } from '@cerc-io/nitro-util';
+import { JSONbigNative, hex2Bytes } from '@cerc-io/nitro-util';
 
 import { createP2PMessageService, waitForPeerInfoExchange } from './utils/index';
 import { DirectFundParams, VirtualFundParams } from './types';
@@ -253,18 +254,8 @@ const main = async () => {
     log(`Ledger channel ${ledgerChannelId.string()} status:\n`, JSONbigNative.stringify(ledgerChannelStatus, null, 2));
   }
 
-  go(async () => {
-    while (true) {
-      // eslint-disable-next-line no-await-in-loop
-      const voucher = await client.receivedVouchers().shift();
-
-      if (voucher === undefined) {
-        break;
-      }
-
-      log(`Received voucher: ${JSONbigNative.stringify(voucher, null, 2)}`);
-    }
-  });
+  // Call async method to log message on receiving vouchers
+  subscribeVoucherLogs(client);
 
   // TODO: Update instructions in browser setup
   // TODO: Update instructions for ts-nitro - go-nitro setup

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -293,6 +293,7 @@ main()
 
 process.on('uncaughtException', (err) => {
   if (err.message.includes(ErrConnectionClosed)) {
+    log('uncaughtException', err.message);
     return;
   }
 

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 import {
   P2PMessageService,
 } from '@cerc-io/nitro-client';

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -2,21 +2,19 @@ import {
   P2PMessageService,
 } from '@cerc-io/nitro-client';
 
-export const createP2PMessageService = async (relayMultiAddr: string, port: number, me: string): Promise<P2PMessageService> => {
-  const keys = await import('@libp2p/crypto/keys');
-
-  // TODO: Generate private key from a string
-  const privateKey = await keys.generateKeyPair('Ed25519');
-
-  return P2PMessageService.newMessageService(
-    relayMultiAddr,
-    '127.0.0.1',
-    port,
-    me,
-    privateKey.bytes,
-    true,
-  );
-};
+export const createP2PMessageService = async (
+  relayMultiAddr: string,
+  port: number,
+  me: string,
+  privateKey: Buffer,
+): Promise<P2PMessageService> => P2PMessageService.newMessageService(
+  relayMultiAddr,
+  '127.0.0.1',
+  port,
+  me,
+  privateKey,
+  true,
+);
 
 // waitForPeerInfoExchange waits for all the P2PMessageServices to receive peer info from each other
 export async function waitForPeerInfoExchange(numOfPeers: number, services: P2PMessageService[]) {

--- a/packages/server/test-e2e/integration.test.ts
+++ b/packages/server/test-e2e/integration.test.ts
@@ -33,7 +33,12 @@ describe('test Client', () => {
     assert(process.env.RELAY_MULTIADDR, 'RELAY_MULTIADDR should be set in .env');
 
     const aliceStore = new MemStore(hex2Bytes(ACTORS.alice.privateKey));
-    const aliceMsgService = await createP2PMessageService(process.env.RELAY_MULTIADDR, ALICE_MESSAGING_PORT, aliceStore.getAddress());
+    const aliceMsgService = await createP2PMessageService(
+      process.env.RELAY_MULTIADDR,
+      ALICE_MESSAGING_PORT,
+      aliceStore.getAddress(),
+      hex2Bytes(ACTORS.alice.privateKey),
+    );
     aliceMetrics = new Metrics();
 
     aliceClient = await setupClient(
@@ -49,7 +54,12 @@ describe('test Client', () => {
     expect(aliceClient.address).to.equal(ACTORS.alice.address);
 
     const bobStore = new MemStore(hex2Bytes(ACTORS.bob.privateKey));
-    const bobMsgService = await createP2PMessageService(process.env.RELAY_MULTIADDR, BOB_MESSAGING_PORT, bobStore.getAddress());
+    const bobMsgService = await createP2PMessageService(
+      process.env.RELAY_MULTIADDR,
+      BOB_MESSAGING_PORT,
+      bobStore.getAddress(),
+      hex2Bytes(ACTORS.bob.privateKey),
+    );
     bobMetrics = new Metrics();
 
     bobClient = await setupClient(

--- a/packages/util/src/helpers.ts
+++ b/packages/util/src/helpers.ts
@@ -1,3 +1,5 @@
+import debug from 'debug';
+
 import {
   P2PMessageService,
   Client,
@@ -12,12 +14,15 @@ import {
   AllocationType,
   Allocations,
 } from '@cerc-io/nitro-client';
+import { JSONbigNative } from '@cerc-io/nitro-util';
 
 import {
   nitroAdjudicatorAddress,
   virtualPaymentAppAddress,
   consensusAppAddress,
 } from './addresses.json';
+
+const log = debug('ts-nitro:util:helpers');
 
 /**
  * setupClient sets up a client using the given args
@@ -112,4 +117,18 @@ export function createOutcome(
       ]),
     }),
   ]);
+}
+
+export async function subscribeVoucherLogs(client: Client): Promise<void> {
+  // Log voucher messages from channel in loop
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const voucher = await client.receivedVouchers().shift();
+
+    if (voucher === undefined) {
+      break;
+    }
+
+    log(`Received voucher: ${JSONbigNative.stringify(voucher, null, 2)}`);
+  }
 }

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -56,10 +56,11 @@ export class Nitro {
     return new Nitro(client, msgService);
   }
 
-  static async clearClientStorage(): Promise<void> {
+  static async clearClientStorage(): Promise<boolean> {
     // Delete all databases in browser
     const dbs = await window.indexedDB.databases();
     dbs.forEach((db) => window.indexedDB.deleteDatabase(db.name!));
+    return true;
   }
 
   // TODO: Implement close method

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 import {
   Client, Destination, DurableStore, MemStore, P2PMessageService, Store,
 } from '@cerc-io/nitro-client';
-import { hex2Bytes } from '@cerc-io/nitro-util';
+import { JSONbigNative, hex2Bytes } from '@cerc-io/nitro-util';
 
 import { createOutcome, setupClient, subscribeVoucherLogs } from './helpers';
 
@@ -129,5 +129,25 @@ export class Nitro {
 
     await this.client.objectiveCompleteChan(closeLedgerChannelObjectiveId).shift();
     log(`Ledger channel with id ${ledgerChannelId.string()} closed`);
+  }
+
+  async getLedgerChannel(ledgerChannel: string): Promise<void> {
+    const ledgerChannelId = new Destination(ledgerChannel);
+    const ledgerChannelStatus = await this.client.getLedgerChannel(ledgerChannelId);
+
+    log(
+      `Ledger channel ${ledgerChannelId.string()} status:\n`,
+      JSONbigNative.stringify(ledgerChannelStatus, null, 2),
+    );
+  }
+
+  async getPaymentChannel(paymentChannel: string): Promise<void> {
+    const paymentChannelId = new Destination(paymentChannel);
+    const paymentChannelStatus = await this.client.getLedgerChannel(paymentChannelId);
+
+    log(
+      `Virtual payment channel ${paymentChannelId.string()} status:\n`,
+      JSONbigNative.stringify(paymentChannelStatus, null, 2),
+    );
   }
 }

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -1,9 +1,9 @@
 import debug from 'debug';
 
 import {
-  Client, Destination, DurableStore, MemStore, P2PMessageService, Store,
+  Client, Destination, DurableStore, MemStore, P2PMessageService, Store, LedgerChannelInfo, PaymentChannelInfo,
 } from '@cerc-io/nitro-client';
-import { JSONbigNative, hex2Bytes } from '@cerc-io/nitro-util';
+import { hex2Bytes } from '@cerc-io/nitro-util';
 
 import { createOutcome, setupClient, subscribeVoucherLogs } from './helpers';
 
@@ -132,23 +132,13 @@ export class Nitro {
     log(`Ledger channel with id ${ledgerChannelId.string()} closed`);
   }
 
-  async getLedgerChannel(ledgerChannel: string): Promise<void> {
+  async getLedgerChannel(ledgerChannel: string): Promise<LedgerChannelInfo> {
     const ledgerChannelId = new Destination(ledgerChannel);
-    const ledgerChannelStatus = await this.client.getLedgerChannel(ledgerChannelId);
-
-    log(
-      `Ledger channel ${ledgerChannelId.string()} status:\n`,
-      JSONbigNative.stringify(ledgerChannelStatus, null, 2),
-    );
+    return this.client.getLedgerChannel(ledgerChannelId);
   }
 
-  async getPaymentChannel(paymentChannel: string): Promise<void> {
+  async getPaymentChannel(paymentChannel: string): Promise<PaymentChannelInfo> {
     const paymentChannelId = new Destination(paymentChannel);
-    const paymentChannelStatus = await this.client.getPaymentChannel(paymentChannelId);
-
-    log(
-      `Virtual payment channel ${paymentChannelId.string()} status:\n`,
-      JSONbigNative.stringify(paymentChannelStatus, null, 2),
-    );
+    return this.client.getPaymentChannel(paymentChannelId);
   }
 }

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -143,7 +143,7 @@ export class Nitro {
 
   async getPaymentChannel(paymentChannel: string): Promise<void> {
     const paymentChannelId = new Destination(paymentChannel);
-    const paymentChannelStatus = await this.client.getLedgerChannel(paymentChannelId);
+    const paymentChannelStatus = await this.client.getPaymentChannel(paymentChannelId);
 
     log(
       `Virtual payment channel ${paymentChannelId.string()} status:\n`,

--- a/packages/util/src/nitro.ts
+++ b/packages/util/src/nitro.ts
@@ -12,21 +12,6 @@ const log = debug('ts-nitro:util:nitro');
 const CHALLENGE_DURATION = 0;
 const ASSET = `0x${'00'.repeat(20)}`;
 
-const createP2PMessageService = async (relayMultiAddr: string, me: string): Promise<P2PMessageService> => {
-  const keys = await import('@libp2p/crypto/keys');
-
-  // TODO: Generate private key from a string
-  const privateKey = await keys.generateKeyPair('Ed25519');
-
-  // Type error thrown in NodeJS build
-  // TODO: Move file to separate package which is only used for browser build
-  return (P2PMessageService as any).newMessageService(
-    relayMultiAddr,
-    me,
-    privateKey.bytes,
-  );
-};
-
 export class Nitro {
   client: Client;
 
@@ -54,7 +39,9 @@ export class Nitro {
       store = new MemStore(hex2Bytes(pk));
     }
 
-    const msgService = await createP2PMessageService(relayMultiaddr, store.getAddress());
+    // Type error thrown in NodeJS build
+    // TODO: Move file to separate package which is only used for browser build
+    const msgService = await (P2PMessageService as any).newMessageService(relayMultiaddr, store.getAddress(), hex2Bytes(pk));
 
     const client = await setupClient(
       msgService,
@@ -76,7 +63,6 @@ export class Nitro {
 
   async addPeerByMultiaddr(address: string, multiaddrString: string): Promise<void> {
     const { multiaddr } = await import('@multiformats/multiaddr');
-
     const multi = multiaddr(multiaddrString);
     await this.msgService.addPeerByMultiaddr(address, multi);
   }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Change CLI to run commands individually
  - Exchange peer info on libp2p `peer:connect` event
- Use private key passed in CLI for message service
- Log received vouchers during payment in client CLI
- Add pay and defund methods in browser app
- Add get channel info methods