### PR TITLE
Port latest changes from go-nitro till commit `818b129` on May 26

### DIFF
--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -6,7 +6,7 @@ import { Buffer } from 'buffer';
 import { ethers } from 'ethers';
 
 import {
-  FieldDescription, NitroSigner, Uint, Uint64, fromJSON, toJSON, zeroValueSignature,
+  FieldDescription, NitroSigner, Uint, Uint64, fromJSON, toJSON, zeroValueSignature, JSONbigNative,
 } from '@cerc-io/nitro-util';
 import { Bytes32 } from '@statechannels/nitro-protocol';
 
@@ -788,7 +788,7 @@ export class Proposal {
       case 'RemoveProposal':
         return this.toRemove.target;
       default:
-        throw new Error('invalid proposal type');
+        throw new Error(`invalid proposal type ${this.constructor.name}`);
     }
   }
 

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -1351,7 +1351,7 @@ export class ConsensusChannel {
       && this._proposalQueue.length > 0
       && this._proposalQueue[this._proposalQueue.length - 1].turnNum + BigInt(1) !== signed.turnNum
     ) {
-      throw new Error('Appending to ConsensusChannel.proposalQueue: not a consecutive TurnNum');
+      throw new Error('appending to ConsensusChannel.proposalQueue: not a consecutive TurnNum');
     }
     (this._proposalQueue ?? []).push(signed);
   }

--- a/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
+++ b/packages/nitro-client/src/channel/consensus-channel/consensus-channel.ts
@@ -1140,10 +1140,6 @@ export class ConsensusChannel {
     return this.current.outcome.fundingTargets();
   }
 
-  accept(p: SignedProposal): void {
-    throw new Error('UNIMPLEMENTED');
-  }
-
   // sign constructs a state.State from the given vars, using the ConsensusChannel's constant
   // values. It signs the resulting state using sk.
   private async sign(vars: Vars, signer: NitroSigner): Promise<Signature> {
@@ -1337,12 +1333,18 @@ export class ConsensusChannel {
     }
 
     const signed = new SignedProposal({ proposal, signature, turnNum: vars.turnNum });
-    this.appendToProposalQueue(signed);
+
+    try {
+      this.appendToProposalQueue(signed);
+    } catch (err) {
+      throw new Error(`could not append to proposal queue: ${err}`);
+    }
+
     return signed;
   }
 
   // appendToProposalQueue safely appends the given SignedProposal to the proposal queue of the receiver.
-  // It will panic if the turn number of the signedproposal is not consecutive with the existing queue.
+  // It will return an error if the turn number of the signedproposal is not consecutive with the existing queue.
   private appendToProposalQueue(signed: SignedProposal) {
     if (
       this._proposalQueue

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -628,7 +628,7 @@ export class Engine {
               this.store.getConsensusChannel.bind(this.store),
             );
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create objective for ${or}: ${err}`);
+            throw new Error(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`);
           }
           this.metrics!.recordObjectiveStarted(vfo.id());
 
@@ -655,7 +655,7 @@ export class Engine {
 
               minAmount = paid;
             } catch (err) {
-              throw new Error(`handleAPIEvent: Could not create objective for ${JSONbigNative.stringify(request)}: ${err}`);
+              throw new Error(`handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`);
             }
           }
 
@@ -672,7 +672,7 @@ export class Engine {
             this.metrics!.recordObjectiveStarted(vdfo.id());
             return await this.attemptProgress(vdfo);
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create objective for ${request}: ${err}`);
+            throw new Error(`handleAPIEvent: Could not create virtualdefund objective for ${request}: ${err}`);
           }
         }
 
@@ -690,7 +690,7 @@ export class Engine {
             this.metrics!.recordObjectiveStarted(dfo.id());
             return await this.attemptProgress(dfo);
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create objective for ${JSONbigNative.stringify(or)}: ${err}`);
+            throw new Error(`handleAPIEvent: Could not create directfund objective for ${JSONbigNative.stringify(or)}: ${err}`);
           }
 
         case or instanceof DirectDefundObjectiveRequest: {
@@ -703,7 +703,7 @@ export class Engine {
               this.store.getConsensusChannelById.bind(this.store),
             );
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create objective for ${JSONbigNative.stringify(request)}: ${err}`);
+            throw new Error(`handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`);
           }
           this.metrics!.recordObjectiveStarted(ddfo.id());
           // If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -252,6 +252,7 @@ export class Engine {
 
     while (true) {
       let res = new EngineEvent();
+      let err: Error | null = null;
 
       this.metrics!.recordQueueLength('api_objective_request_queue', this.objectiveRequestsFromAPI.channelLength());
       this.metrics!.recordQueueLength('api_payment_request_queue', this.paymentRequestsFromAPI.channelLength());
@@ -259,50 +260,43 @@ export class Engine {
       this.metrics!.recordQueueLength('messages_queue', this.fromMsg.channelLength());
       this.metrics!.recordQueueLength('proposal_queue', this.fromLedger.channelLength());
 
-      try {
-        /* eslint-disable no-await-in-loop */
-        /* eslint-disable default-case */
-        switch (await Channel.select([
-          this.objectiveRequestsFromAPI.shift(),
-          this.paymentRequestsFromAPI.shift(),
-          this.fromChain.shift(),
-          this.fromMsg.shift(),
-          this.fromLedger.shift(),
-          this.stop.shift(),
-        ])) {
-          case this.objectiveRequestsFromAPI:
-            res = await this.handleObjectiveRequest(this.objectiveRequestsFromAPI.value());
-            break;
+      /* eslint-disable no-await-in-loop */
+      /* eslint-disable default-case */
+      switch (await Channel.select([
+        this.objectiveRequestsFromAPI.shift(),
+        this.paymentRequestsFromAPI.shift(),
+        this.fromChain.shift(),
+        this.fromMsg.shift(),
+        this.fromLedger.shift(),
+        this.stop.shift(),
+      ])) {
+        case this.objectiveRequestsFromAPI:
+          [res, err] = await this.handleObjectiveRequest(this.objectiveRequestsFromAPI.value());
+          break;
 
-          case this.paymentRequestsFromAPI:
-            res = await this.handlePaymentRequest(this.paymentRequestsFromAPI.value());
-            break;
+        case this.paymentRequestsFromAPI:
+          [res, err] = await this.handlePaymentRequest(this.paymentRequestsFromAPI.value());
+          break;
 
-          case this.fromChain:
-            res = await this.handleChainEvent(this.fromChain.value());
-            break;
+        case this.fromChain:
+          [res, err] = await this.handleChainEvent(this.fromChain.value());
+          break;
 
-          case this.fromMsg: {
-            let err: Error | undefined;
-            [res, err] = await this.handleMessage(this.fromMsg.value());
+        case this.fromMsg:
+          [res, err] = await this.handleMessage(this.fromMsg.value());
+          break;
 
-            if (err) {
-              throw err;
-            }
+        case this.fromLedger:
+          [res, err] = await this.handleProposal(this.fromLedger.value());
+          break;
 
-            break;
-            // TODO: Return errors from other handlers as well?
-          }
-          case this.fromLedger:
-            res = await this.handleProposal(this.fromLedger.value());
-            break;
+        case this.stop:
+          return;
+      }
 
-          case this.stop:
-            return;
-        }
-      } catch (err) {
-        // Handle errors
-        this.checkError(err as Error);
+      // Handle errors
+      if (err) {
+        this.checkError(err);
       }
 
       // Only send out an event if there are changes
@@ -321,7 +315,7 @@ export class Engine {
   // handleProposal handles a Proposal returned to the engine from
   // a running ledger channel by pulling its corresponding objective
   // from the store and attempting progress.
-  private async handleProposal(proposal: Proposal): Promise<EngineEvent> {
+  private async handleProposal(proposal: Proposal): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
       const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleProposal.name);
@@ -329,11 +323,17 @@ export class Engine {
 
       assert(this.store);
       const id = getProposalObjectiveId(proposal);
-      const obj = await this.store.getObjectiveById(id);
+
+      let obj: Objective;
+      try {
+        obj = await this.store.getObjectiveById(id);
+      } catch (err) {
+        return [new EngineEvent(), err as Error];
+      }
 
       if (obj.getStatus() === ObjectiveStatus.Completed) {
         this.logger(`Ignoring proposal for complected objective ${obj.id()}`);
-        return new EngineEvent();
+        return [new EngineEvent(), null];
       }
 
       return await this.attemptProgress(obj);
@@ -350,7 +350,7 @@ export class Engine {
   //   - generates an updated objective,
   //   - attempts progress on the target Objective,
   //   - attempts progress on related objectives which may have become unblocked.
-  private async handleMessage(message: Message): Promise<[EngineEvent, Error | undefined]> {
+  private async handleMessage(message: Message): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
       const completeRecordFunction = () => this.metrics!.recordFunctionDuration(this.handleMessage.name);
@@ -380,7 +380,11 @@ export class Engine {
             if (objective instanceof DirectDefundObjective) {
               // If we just approved a direct defund objective, destroy the consensus channel
               // to prevent it being used (a Channel will now take over governance)
-              await this.store.destroyConsensusChannel(objective.c!.id);
+              try {
+                await this.store.destroyConsensusChannel(objective.c!.id);
+              } catch (err) {
+                return [new EngineEvent(), err as Error];
+              }
             }
           } else {
             let sideEffects: SideEffects;
@@ -421,10 +425,9 @@ export class Engine {
           return [new EngineEvent(), err as Error];
         }
 
-        let progressEvent: EngineEvent;
-        try {
-          progressEvent = await this.attemptProgress(updatedObjective);
-        } catch (err) {
+        const [progressEvent, err] = await this.attemptProgress(updatedObjective);
+
+        if (err) {
           return [new EngineEvent(), err as Error];
         }
 
@@ -463,10 +466,9 @@ export class Engine {
           return [new EngineEvent(), err as Error];
         }
 
-        let progressEvent: EngineEvent;
-        try {
-          progressEvent = await this.attemptProgress(updatedObjective);
-        } catch (err) {
+        const [progressEvent, err] = await this.attemptProgress(updatedObjective);
+
+        if (err) {
           return [new EngineEvent(), err as Error];
         }
 
@@ -532,7 +534,7 @@ export class Engine {
         allCompleted.paymentChannelUpdates.push(info);
       }
 
-      return [allCompleted, undefined];
+      return [allCompleted, null];
     } finally {
       if (deferredCompleteRecordFunction) {
         deferredCompleteRecordFunction();
@@ -545,7 +547,7 @@ export class Engine {
   //   - reads an objective from the store,
   //   - generates an updated objective, and
   //   - attempts progress.
-  private async handleChainEvent(chainEvent: ChainEvent): Promise<EngineEvent> {
+  private async handleChainEvent(chainEvent: ChainEvent): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
       const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleChainEvent.name);
@@ -561,7 +563,7 @@ export class Engine {
         // TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
         // for now we can ignore channels we aren't involved in
         // in the future the chain service should allow us to register for specific channels
-        return new EngineEvent();
+        return [new EngineEvent(), null];
       }
 
       // Workaround for Go type assertion syntax
@@ -569,14 +571,19 @@ export class Engine {
       ok = 'updateWithChainEvent' in objective && typeof objective.updateWithChainEvent === 'function';
       const eventHandler = objective as unknown as ChainEventHandler;
       if (!ok) {
-        throw new ErrUnhandledChainEvent({
+        return [new EngineEvent(), new ErrUnhandledChainEvent({
           event: chainEvent,
           objective,
           reason: 'objective does not handle chain events',
-        });
+        })];
       }
 
-      const updatedEventHandler = eventHandler.updateWithChainEvent(chainEvent);
+      let updatedEventHandler: Objective;
+      try {
+        updatedEventHandler = eventHandler.updateWithChainEvent(chainEvent);
+      } catch (err) {
+        return [new EngineEvent(), err as Error];
+      }
 
       return await this.attemptProgress(updatedEventHandler);
     } finally {
@@ -588,7 +595,7 @@ export class Engine {
 
   // handleObjectiveRequest handles an ObjectiveRequest (triggered by a client API call).
   // It will attempt to spawn a new, approved objective.
-  private async handleObjectiveRequest(or: ObjectiveRequest): Promise<EngineEvent> {
+  private async handleObjectiveRequest(or: ObjectiveRequest): Promise<[EngineEvent, Error | null]> {
     let deferredSignalObjectiveStarted;
     let deferredCompleteRecordFunction;
     try {
@@ -605,7 +612,7 @@ export class Engine {
       try {
         chainId = await this.chain.getChainId();
       } catch (err) {
-        throw new Error(`could get chain id from chain service: ${err}`);
+        return [new EngineEvent(), new Error(`could get chain id from chain service: ${err}`)];
       }
 
       const objectiveId = or.id(myAddress, chainId);
@@ -628,7 +635,7 @@ export class Engine {
               this.store.getConsensusChannel.bind(this.store),
             );
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`);
+            return [new EngineEvent(), new Error(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`)];
           }
           this.metrics!.recordObjectiveStarted(vfo.id());
 
@@ -638,7 +645,7 @@ export class Engine {
             try {
               await this.registerPaymentChannel(vfo);
             } catch (err) {
-              throw new Error(`could not register channel with payment/receipt manager: ${err}`);
+              return [new EngineEvent(), new Error(`could not register channel with payment/receipt manager: ${err}`)];
             }
           }
 
@@ -655,12 +662,16 @@ export class Engine {
 
               minAmount = paid;
             } catch (err) {
-              throw new Error(`handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`);
+              return [
+                new EngineEvent(),
+                new Error(`handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
+              ];
             }
           }
 
+          let vdfo: VirtualDefundObjective;
           try {
-            const vdfo = await VirtualDefundObjective.newObjective(
+            vdfo = await VirtualDefundObjective.newObjective(
               request,
               true,
               myAddress,
@@ -670,15 +681,17 @@ export class Engine {
             );
 
             this.metrics!.recordObjectiveStarted(vdfo.id());
-            return await this.attemptProgress(vdfo);
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create virtualdefund objective for ${request}: ${err}`);
+            return [new EngineEvent(), new Error(`handleAPIEvent: Could not create virtualdefund objective for ${request}: ${err}`)];
           }
+
+          return await this.attemptProgress(vdfo);
         }
 
-        case or instanceof DirectFundObjectiveRequest:
+        case or instanceof DirectFundObjectiveRequest: {
+          let dfo: DirectFundObjective;
           try {
-            const dfo = await DirectFundObjective.newObjective(
+            dfo = await DirectFundObjective.newObjective(
               or as DirectFundObjectiveRequest,
               true,
               myAddress,
@@ -688,10 +701,12 @@ export class Engine {
             );
 
             this.metrics!.recordObjectiveStarted(dfo.id());
-            return await this.attemptProgress(dfo);
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create directfund objective for ${JSONbigNative.stringify(or)}: ${err}`);
+            return [new EngineEvent(), new Error(`handleAPIEvent: Could not create directfund objective for ${JSONbigNative.stringify(or)}: ${err}`)];
           }
+
+          return await this.attemptProgress(dfo);
+        }
 
         case or instanceof DirectDefundObjectiveRequest: {
           const request = or as DirectDefundObjectiveRequest;
@@ -703,21 +718,24 @@ export class Engine {
               this.store.getConsensusChannelById.bind(this.store),
             );
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`);
+            return [
+              new EngineEvent(),
+              new Error(`handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
+            ];
           }
           this.metrics!.recordObjectiveStarted(ddfo.id());
           // If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
           try {
             await this.store.destroyConsensusChannel(request.channelId);
           } catch (err) {
-            throw new Error(`handleAPIEvent: Could not destroy consensus channel for ${request}: ${err}`);
+            return [new EngineEvent(), new Error(`handleAPIEvent: Could not destroy consensus channel for ${request}: ${err}`)];
           }
 
           return await this.attemptProgress(ddfo);
         }
 
         default:
-          throw new Error(`handleAPIEvent: Unknown objective type ${typeof or}`);
+          return [new EngineEvent(), new Error(`handleAPIEvent: Unknown objective type ${typeof or}`)];
       }
     } finally {
       if (deferredSignalObjectiveStarted) {
@@ -731,11 +749,11 @@ export class Engine {
 
   // handlePaymentRequest handles an PaymentRequest (triggered by a client API call).
   // It prepares and dispatches a payment message to the counterparty.
-  private async handlePaymentRequest(request: PaymentRequest): Promise<EngineEvent> {
+  private async handlePaymentRequest(request: PaymentRequest): Promise<[EngineEvent, Error | null]> {
     const ee = new EngineEvent();
 
     if (_.isEqual(request, {})) {
-      throw new Error('handleAPIEvent: Empty payment request');
+      return [ee, new Error('handleAPIEvent: Empty payment request')];
     }
 
     const cId = request.channelId;
@@ -743,27 +761,27 @@ export class Engine {
     try {
       voucher = await this.vm!.pay(cId, request.amount, this.store!.getChannelSigner());
     } catch (err) {
-      throw new Error(`handleAPIEvent: Error making payment: ${err}`);
+      return [ee, new Error(`handleAPIEvent: Error making payment: ${err}`)];
     }
 
     const [c, ok] = await this.store!.getChannelById(cId);
 
     if (!ok) {
-      throw new Error(`handleAPIEvent: Could not get channel from the store ${cId}`);
+      return [ee, new Error(`handleAPIEvent: Could not get channel from the store ${cId}`)];
     }
 
     const payer = getPayer(c.participants);
     const payee = getPayee(c.participants);
 
     if (payer !== this.store!.getAddress()) {
-      throw new Error(`handleAPIEvent: Not the sender in channel ${cId}`);
+      return [ee, new Error(`handleAPIEvent: Not the sender in channel ${cId}`)];
     }
 
     let info: PaymentChannelInfo;
     try {
       info = await getPaymentChannelInfo(cId, this.store!, this.vm!);
     } catch (err) {
-      throw new Error(`handleAPIEvent: Error querying channel info: ${err}`);
+      return [ee, new Error(`handleAPIEvent: Error querying channel info: ${err}`)];
     }
 
     ee.paymentChannelUpdates = [...ee.paymentChannelUpdates, info];
@@ -772,11 +790,14 @@ export class Engine {
       messagesToSend: Message.createVoucherMessage(voucher, payee),
     });
 
-    await this.executeSideEffects(se);
+    try {
+      await this.executeSideEffects(se);
+    } catch (err) {
+      return [ee, err as Error];
+    }
 
     this._sentVouchers?.push(voucher);
-
-    return ee;
+    return [ee, null];
   }
 
   // sendMessages sends out the messages and records the metrics.
@@ -836,7 +857,7 @@ export class Engine {
   //  3. It commits the cranked objective to the store
   //  4. It executes any side effects that were declared during cranking
   //  5. It updates progress metadata in the store
-  private async attemptProgress(objective: Objective): Promise<EngineEvent> {
+  private async attemptProgress(objective: Objective): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
       const completeRecordFunction = this.metrics!.recordFunctionDuration(this.attemptProgress.name);
@@ -847,11 +868,24 @@ export class Engine {
       assert(this.store);
       const signer = this.store.getChannelSigner();
 
-      const [crankedObjective, sideEffects, waitingFor] = await objective.crank(signer);
+      let crankedObjective: Objective;
+      let sideEffects: SideEffects;
+      let waitingFor: string;
+
+      try {
+        [crankedObjective, sideEffects, waitingFor] = await objective.crank(signer);
+      } catch (err) {
+        return [outgoing, err as Error];
+      }
 
       await this.store.setObjective(crankedObjective);
 
-      const notifEvents = await this.generateNotifications(crankedObjective);
+      let notifEvents: EngineEvent;
+      try {
+        notifEvents = await this.generateNotifications(crankedObjective);
+      } catch (err) {
+        return [new EngineEvent(), err as Error];
+      }
 
       outgoing.merge(notifEvents);
 
@@ -862,18 +896,22 @@ export class Engine {
       // Probably should have a better check that only adds it to CompletedObjectives if it was completed in this crank
       if (waitingFor === 'WaitingForNothing') {
         outgoing.completedObjectives = outgoing.completedObjectives.concat(crankedObjective);
-        await this.store.releaseChannelFromOwnership(crankedObjective.ownsChannel());
+        try {
+          await this.store.releaseChannelFromOwnership(crankedObjective.ownsChannel());
+        } catch (err) {
+          return [outgoing, err as Error];
+        }
 
         try {
           await this.spawnConsensusChannelIfDirectFundObjective(crankedObjective);
         } catch (err) {
-          return outgoing;
+          return [outgoing, err as Error];
         }
       }
 
       await this.executeSideEffects(sideEffects);
 
-      return outgoing;
+      return [outgoing, null];
     } finally {
       if (deferredCompleteRecordFunction) {
         deferredCompleteRecordFunction();

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -951,15 +951,26 @@ export class Engine {
 
       if (crankedObjective instanceof DirectFundObjective) {
         const dfo = crankedObjective as DirectFundObjective;
-        const c: ConsensusChannel = dfo.createConsensusChannel();
-        try {
-          assert(this.store);
-          await this.store.setConsensusChannel(c);
+        let c: ConsensusChannel;
+        assert(this.store);
 
+        try {
+          c = dfo.createConsensusChannel();
+        } catch (err) {
+          throw new Error(`could not create consensus channel for objective ${crankedObjective.id()}: ${err}`);
+        }
+
+        try {
+          await this.store.setConsensusChannel(c);
+        } catch (err) {
+          throw new Error(`could not store consensus channel for objective ${crankedObjective.id()}: ${err}`);
+        }
+
+        try {
           // Destroy the channel since the consensus channel takes over governance:
           await this.store.destroyChannel(c.id);
         } catch (err) {
-          throw new Error(`Could not create, store, or destroy consensus channel for objective ${crankedObjective.id()}: ${err}`);
+          throw new Error(`Could not destroy consensus channel for objective ${crankedObjective.id()}: ${err}`);
         }
       }
     } finally {

--- a/packages/nitro-client/src/client/engine/engine.ts
+++ b/packages/nitro-client/src/client/engine/engine.ts
@@ -707,7 +707,12 @@ export class Engine {
           }
           this.metrics!.recordObjectiveStarted(ddfo.id());
           // If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
-          await this.store.destroyConsensusChannel(request.channelId);
+          try {
+            await this.store.destroyConsensusChannel(request.channelId);
+          } catch (err) {
+            throw new Error(`handleAPIEvent: Could not destroy consensus channel for ${request}: ${err}`);
+          }
+
           return await this.attemptProgress(ddfo);
         }
 

--- a/packages/nitro-client/src/client/engine/store/durablestore.ts
+++ b/packages/nitro-client/src/client/engine/store/durablestore.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+/* eslint-disable no-useless-catch */
 import _ from 'lodash';
 import { Buffer } from 'buffer';
 import { Level } from 'level';
@@ -71,8 +71,7 @@ export class DurableStore implements Store {
     try {
       subDb = this.db!.sublevel<string, V>(name, options);
     } catch (err) {
-      this.checkError(err as Error);
-      assert(subDb);
+      throw err;
     }
 
     return subDb;
@@ -186,7 +185,7 @@ export class DurableStore implements Store {
         try {
           await this.channelToObjective!.put(obj.ownsChannel().string(), obj.id());
         } catch (err) {
-          this.checkError(err as Error);
+          throw new Error(`cannot transfer ownership of channel: ${err}`);
         }
       }
 
@@ -208,7 +207,7 @@ export class DurableStore implements Store {
     try {
       await this.channels!.del(id.string());
     } catch (err) {
-      this.checkError(err as Error);
+      throw err;
     }
   }
 
@@ -227,7 +226,7 @@ export class DurableStore implements Store {
     try {
       await this.consensusChannels!.del(id.string());
     } catch (err) {
-      this.checkError(err as Error);
+      throw err;
     }
   }
 
@@ -570,14 +569,6 @@ export class DurableStore implements Store {
     try {
       await this.channelToObjective!.del(channelId.string());
     } catch (err) {
-      this.checkError(err as Error);
-    }
-  }
-
-  // checkError is a helper function that panics if an error is not nil
-  // TODO: Longer term we should return errors instead of panicking
-  private checkError(err: Error) {
-    if (err) {
       throw err;
     }
   }

--- a/packages/nitro-client/src/client/engine/store/durablestore.ts
+++ b/packages/nitro-client/src/client/engine/store/durablestore.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-useless-catch */
 import _ from 'lodash';
 import { Buffer } from 'buffer';
 import { Level } from 'level';
@@ -67,13 +66,7 @@ export class DurableStore implements Store {
     name: string,
     options: AbstractSublevelOptions<string, V> = {},
   ): AbstractSublevel<Level<string, Buffer>, string | Buffer | Uint8Array, string, V> {
-    let subDb;
-    try {
-      subDb = this.db!.sublevel<string, V>(name, options);
-    } catch (err) {
-      throw err;
-    }
-
+    const subDb = this.db!.sublevel<string, V>(name, options);
     return subDb;
   }
 
@@ -204,11 +197,7 @@ export class DurableStore implements Store {
 
   // destroyChannel deletes the channel with id id.
   async destroyChannel(id: Destination): Promise<void> {
-    try {
-      await this.channels!.del(id.string());
-    } catch (err) {
-      throw err;
-    }
+    await this.channels!.del(id.string());
   }
 
   // SetConsensusChannel sets the channel in the store.
@@ -223,11 +212,7 @@ export class DurableStore implements Store {
 
   // DestroyChannel deletes the channel with id id.
   async destroyConsensusChannel(id: Destination): Promise<void> {
-    try {
-      await this.consensusChannels!.del(id.string());
-    } catch (err) {
-      throw err;
-    }
+    await this.consensusChannels!.del(id.string());
   }
 
   // GetChannelById retrieves the channel with the supplied id, if it exists.
@@ -566,11 +551,7 @@ export class DurableStore implements Store {
   }
 
   async releaseChannelFromOwnership(channelId: Destination): Promise<void> {
-    try {
-      await this.channelToObjective!.del(channelId.string());
-    } catch (err) {
-      throw err;
-    }
+    await this.channelToObjective!.del(channelId.string());
   }
 
   setVoucherInfo(channelId: Destination, v: VoucherInfo): void {

--- a/packages/nitro-client/src/client/query/query.ts
+++ b/packages/nitro-client/src/client/query/query.ts
@@ -151,7 +151,8 @@ export const getAllLedgerChannels = async (store: Store, consensusAppDefinition:
   const allChannels = await store.getChannelsByAppDefinition(consensusAppDefinition);
 
   for (const c of allChannels) {
-    toReturn.push(constructLedgerInfoFromChannel(c));
+    const l = constructLedgerInfoFromChannel(c);
+    toReturn.push(l);
   }
 
   return toReturn;

--- a/packages/nitro-client/src/payments/voucher-manager.ts
+++ b/packages/nitro-client/src/payments/voucher-manager.ts
@@ -54,7 +54,6 @@ export class VoucherManager {
 
   // Remove deletes the channel's status
   remove(channelId: Destination): void {
-    // TODO: Return error instead of panicking
     this.store.removeVoucherInfo(channelId);
   }
 

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -73,7 +73,12 @@ const channelsExistWithCounterparty = async (
   getChannels: GetChannelsByParticipantFunction,
   getTwoPartyConsensusLedger: GetTwoPartyConsensusLedgerFunction,
 ): Promise<boolean> => {
-  const channels = await getChannels(counterparty);
+  let channels: channel.Channel[];
+  try {
+    channels = await getChannels(counterparty);
+  } catch (err) {
+    return false;
+  }
 
   for (const c of channels) {
     if ((c.participants ?? []).length === 2) {
@@ -182,7 +187,13 @@ export class Objective implements ObjectiveInterface {
       throw new Error(`could not create new objective: ${err}`);
     }
 
-    if (await channelsExistWithCounterparty(request.counterParty, getChannels, getTwoPartyConsensusLedger)) {
+    let channelExists: boolean;
+    try {
+      channelExists = await channelsExistWithCounterparty(request.counterParty, getChannels, getTwoPartyConsensusLedger);
+    } catch (err) {
+      throw new Error(`counterparty check failed: ${err}`);
+    }
+    if (channelExists) {
       throw new Error(`A channel already exists with counterparty ${request.counterParty}`);
     }
 

--- a/packages/nitro-client/src/protocols/directfund/directfund.ts
+++ b/packages/nitro-client/src/protocols/directfund/directfund.ts
@@ -73,12 +73,7 @@ const channelsExistWithCounterparty = async (
   getChannels: GetChannelsByParticipantFunction,
   getTwoPartyConsensusLedger: GetTwoPartyConsensusLedgerFunction,
 ): Promise<boolean> => {
-  let channels: channel.Channel[];
-  try {
-    channels = await getChannels(counterparty);
-  } catch (err) {
-    return false;
-  }
+  const channels = await getChannels(counterparty);
 
   for (const c of channels) {
     if ((c.participants ?? []).length === 2) {

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -415,7 +415,8 @@ export class Objective implements ObjectiveInterface {
 
   // finalState returns the final state for the virtual channel
   private generateFinalState(): State {
-    const vp = new VariablePart({ outcome: new Exit([this.generateFinalOutcome()]), turnNum: FinalTurnNum, isFinal: true });
+    const exit = this.generateFinalOutcome();
+    const vp = new VariablePart({ outcome: new Exit([exit]), turnNum: FinalTurnNum, isFinal: true });
     return stateFromFixedAndVariablePart(this.v!, vp);
   }
 
@@ -542,7 +543,11 @@ export class Objective implements ObjectiveInterface {
       let s: State;
 
       if (updated.isAlice()) {
-        s = updated.generateFinalState();
+        try {
+          s = updated.generateFinalState();
+        } catch (err) {
+          throw new Error(`could not generate final state: ${err}`);
+        }
       } else {
         s = updated.finalState();
       }
@@ -753,7 +758,14 @@ export class Objective implements ObjectiveInterface {
 
     const updated = this.clone();
 
-    if (_.isEqual(sp.proposal.target(), this.vId())) {
+    let target: Destination;
+    try {
+      target = sp.proposal.target();
+    } catch (err) {
+      throw new Error(`could not get target from signed proposal: ${err}`);
+    }
+
+    if (_.isEqual(target, this.vId())) {
       let err: Error | undefined;
 
       switch (true) {

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -402,7 +402,7 @@ export class Objective implements ObjectiveInterface {
 
   private generateFinalOutcome(): SingleAssetExit {
     if (Number(this.myRole) !== 0) {
-      throw new Error('Only Alice should call generateFinalOutcome');
+      throw new Error('only Alice should call generateFinalOutcome');
     }
 
     // Since Alice is responsible for issuing vouchers she always has the largest payment amount

--- a/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
+++ b/packages/nitro-client/src/protocols/virtualdefund/virtualdefund.ts
@@ -758,14 +758,7 @@ export class Objective implements ObjectiveInterface {
 
     const updated = this.clone();
 
-    let target: Destination;
-    try {
-      target = sp.proposal.target();
-    } catch (err) {
-      throw new Error(`could not get target from signed proposal: ${err}`);
-    }
-
-    if (_.isEqual(target, this.vId())) {
+    if (_.isEqual(sp.proposal.target(), this.vId())) {
       let err: Error | undefined;
 
       switch (true) {

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -602,8 +602,8 @@ export class Objective implements ObjectiveInterface, ProposalReceiver {
     if (!this.isBob()) {
       toMyRightId = this.toMyRight!.channel!.id; // Avoid this if it is nil
     }
-    const target = sp.proposal.target();
-    if (_.isEqual(target, this.v!.id)) {
+
+    if (_.isEqual(sp.proposal.target(), this.v!.id)) {
       let err: Error | undefined;
       switch (true) {
         case _.isEqual(sp.proposal.ledgerID, new Destination()):

--- a/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
+++ b/packages/nitro-client/src/protocols/virtualfund/virtualfund.ts
@@ -602,8 +602,8 @@ export class Objective implements ObjectiveInterface, ProposalReceiver {
     if (!this.isBob()) {
       toMyRightId = this.toMyRight!.channel!.id; // Avoid this if it is nil
     }
-
-    if (_.isEqual(sp.proposal.target(), this.v!.id)) {
+    const target = sp.proposal.target();
+    if (_.isEqual(target, this.v!.id)) {
       let err: Error | undefined;
       switch (true) {
         case _.isEqual(sp.proposal.ledgerID, new Destination()):

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,7 +8,7 @@ import 'dotenv/config';
 import { utils } from '@cerc-io/nitro-client';
 import { JSONbigNative, hex2Bytes, DEFAULT_CHAIN_URL } from '@cerc-io/nitro-util';
 
-import { waitForPeerInfoExchange } from './utils/index';
+import { waitForMultiplePeers } from './utils/index';
 import contractAddresses from './nitro-addresses.json';
 
 const log = debug('ts-nitro:server');
@@ -159,7 +159,7 @@ const main = async () => {
   if (intermediariesCount > 0) {
     log(`Waiting for ${intermediariesCount} intermediaries to be discovered`);
   }
-  await waitForPeerInfoExchange(intermediariesCount - peersToAdd.length + 1, [nitro.msgService]);
+  await waitForMultiplePeers(intermediariesCount - peersToAdd.length + 1, [nitro.msgService]);
 
   // Check that all required peers are dialable
   for await (const peerToConnect of peersToConnect) {

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -9,3 +9,11 @@ export async function waitForPeerInfoExchange(services: P2PMessageService[]) {
     await Promise.all(services.map((service) => service.peerInfoReceived().shift()));
   }
 }
+
+// waitForMultiplePeers waits for all the P2PMessageServices to receive peer info from each other
+export async function waitForMultiplePeers(numOfPeers: number, services: P2PMessageService[]) {
+  for (let i = 0; i < numOfPeers; i += 1) {
+    /* eslint-disable no-await-in-loop */
+    await Promise.all(services.map((service) => service.peerInfoReceived().shift()));
+  }
+}

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -10,7 +10,7 @@ export async function waitForPeerInfoExchange(services: P2PMessageService[]) {
   }
 }
 
-// waitForMultiplePeers waits for all the P2PMessageServices to receive peer info from each other
+// waitForMultiplePeers waits for peer info to be received from given number of peers
 export async function waitForMultiplePeers(numOfPeers: number, services: P2PMessageService[]) {
   for (let i = 0; i < numOfPeers; i += 1) {
     /* eslint-disable no-await-in-loop */

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -3,8 +3,8 @@ import {
 } from '@cerc-io/nitro-client';
 
 // waitForPeerInfoExchange waits for all the P2PMessageServices to receive peer info from each other
-export async function waitForPeerInfoExchange(numOfPeers: number, services: P2PMessageService[]) {
-  for (let i = 0; i < numOfPeers; i += 1) {
+export async function waitForPeerInfoExchange(services: P2PMessageService[]) {
+  for (let i = 0; i < services.length - 1; i += 1) {
     /* eslint-disable no-await-in-loop */
     await Promise.all(services.map((service) => service.peerInfoReceived().shift()));
   }

--- a/packages/server/test-e2e/integration.test.ts
+++ b/packages/server/test-e2e/integration.test.ts
@@ -238,7 +238,7 @@ describe('test payment flows', () => {
       [aliceClient, aliceMsgService, aliceMetrics] = await createClient(ACTORS.alice, contractAddresses);
       [bobClient, bobMsgService, bobMetrics] = await createClient(ACTORS.bob, contractAddresses);
 
-      await waitForPeerInfoExchange(1, [aliceMsgService, bobMsgService]);
+      await waitForPeerInfoExchange([aliceMsgService, bobMsgService]);
 
       expect(aliceMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.alice.address));
       expect(bobMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_CLIENT_INSTANTIATION, ACTORS.bob.address));
@@ -452,7 +452,7 @@ describe('test payment flows', () => {
       [bobClient, bobMsgService] = await createClient(ACTORS.bob, contractAddresses);
       [charlieClient, charlieMsgService] = await createClient(ACTORS.charlie, contractAddresses);
 
-      await waitForPeerInfoExchange(2, [aliceMsgService, bobMsgService, charlieMsgService]);
+      await waitForPeerInfoExchange([aliceMsgService, bobMsgService, charlieMsgService]);
     });
 
     it('should create ledger channels', async () => {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Refactoring `waitForPeerInfoExchange` helper method
- Add objective type to engine error messages
- Clean up panics in go-nitro
  - Handle errors in ts-nitro