### PR TITLE
Implement Go Context in ts-nitro

### DIFF
--- a/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
@@ -72,7 +72,7 @@ export class EthChainService implements ChainService {
 
   private ctx: Context;
 
-  private cancel: (reason ?: any) => void;
+  private cancel: () => void;
 
   private wg?: WaitGroup;
 
@@ -189,10 +189,10 @@ export class EthChainService implements ChainService {
     /* eslint-disable default-case */
     while (true) {
       switch (await Channel.select([
-        ctx.done.shift(),
+        this.ctx.done.shift(),
         errChan.shift(),
       ])) {
-        case ctx.done: {
+        case this.ctx.done: {
           this.wg!.done();
           return;
         }

--- a/packages/nitro-util/package.json
+++ b/packages/nitro-util/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@statechannels/nitro-protocol": "^2.0.0-alpha.4",
+    "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "assert": "^2.0.0",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",

--- a/packages/nitro-util/src/context.ts
+++ b/packages/nitro-util/src/context.ts
@@ -1,0 +1,23 @@
+import type { ReadWriteChannel } from '@cerc-io/ts-channel';
+import Channel from '@cerc-io/ts-channel';
+
+export class Context {
+  ctx: AbortController;
+
+  done: ReadWriteChannel<unknown>;
+
+  constructor() {
+    this.ctx = new AbortController();
+    this.done = Channel();
+
+    this.ctx.signal.addEventListener('abort', () => {
+      this.done.close();
+    });
+  }
+
+  withCancel(): () => void {
+    return () => {
+      this.ctx.abort();
+    };
+  }
+}

--- a/packages/nitro-util/src/index.ts
+++ b/packages/nitro-util/src/index.ts
@@ -7,6 +7,7 @@ export * from './contract-bindings';
 export * from './types';
 export * from './constants';
 export * from './deploy-contracts';
+export * from './context';
 
 export {
   INitroTypes, ExitFormat, DepositedEventObject, AllocationUpdatedEventObject, ConcludedEventObject,


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Refactor the usage of Abort Controller into Context
- Use Context in engine, client and eth-chain-service