### PR TITLE
Change Hardhat chain mining mode to interval mining

### DIFF
--- a/packages/server/hardhat.config.ts
+++ b/packages/server/hardhat.config.ts
@@ -2,6 +2,14 @@ import { HardhatUserConfig } from 'hardhat/config';
 
 const config: HardhatUserConfig = {
   solidity: '0.8.18',
+  networks: {
+    hardhat: {
+      mining: {
+        auto: false,
+        interval: 5000,
+      },
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

Problem:
In MobyMask app, old chain events are fetched (from a previously run chain at same block)
Browser app is using MetaMask and it seems to be caching the events fetched

Fix:
Change Hardhat mining mode to interval mining so that same block is not encountered in tests after restarting chain