### PR TITLE
Port latest changes from go-nitro till commit `18d7bd4` on August 14

### DIFF
--- a/packages/nitro-node/src/node/node.ts
+++ b/packages/nitro-node/src/node/node.ts
@@ -240,7 +240,6 @@ export class Node {
 
     for await (const updated of update.ledgerChannelUpdates) {
       try {
-        // TODO: Implement
         this.channelNotifier!.notifyLedgerUpdated(updated);
       } catch (err) {
         await this.handleError(err as Error);
@@ -249,7 +248,6 @@ export class Node {
 
     for await (const updated of update.paymentChannelUpdates) {
       try {
-        // TODO: Implement
         this.channelNotifier!.notifyPaymentUpdated(updated);
       } catch (err) {
         await this.handleError(err as Error);


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Replace `handleEngineEvent` goroutine and channel with callback