### PR TITLE
Port latest changes from go-nitro till commit `6dcbb2b` on August 17

### DIFF
--- a/packages/nitro-node/package.json
+++ b/packages/nitro-node/package.json
@@ -59,6 +59,7 @@
     "@statechannels/exit-format": "^0.2.0",
     "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.0",
     "assert": "^2.0.0",
+    "async-mutex": "^0.4.0",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
     "heap": "^0.2.7",

--- a/packages/nitro-node/src/channel/channel.ts
+++ b/packages/nitro-node/src/channel/channel.ts
@@ -127,6 +127,7 @@ export class Channel extends FixedPart {
       d.signedStateForTurnNum.set(key, value);
     });
     d.onChainFunding = this.onChainFunding.clone();
+    d.latestBlockNumber = this.latestBlockNumber;
     Object.assign(d, super.clone());
 
     return d;
@@ -340,18 +341,18 @@ export class Channel extends FixedPart {
       return this; // ignore stale information TODO: is this reorg safe?
     }
     this.latestBlockNumber = event.blockNum();
-    switch (true) {
-      case event instanceof AllocationUpdatedEvent: {
+    switch (event.constructor) {
+      case AllocationUpdatedEvent: {
         const e = event as AllocationUpdatedEvent;
         this.onChainFunding.value.set(e.assetAndAmount.assetAddress, e.assetAndAmount.assetAmount!);
         break;
       }
-      case event instanceof DepositedEvent: {
+      case DepositedEvent: {
         const e = event as DepositedEvent;
         this.onChainFunding.value.set(e.asset, e.nowHeld!);
         break;
       }
-      case event instanceof ConcludedEvent: {
+      case ConcludedEvent: {
         break;
       }
       default: {

--- a/packages/nitro-node/src/channel/channel.ts
+++ b/packages/nitro-node/src/channel/channel.ts
@@ -14,6 +14,9 @@ import { MaxTurnNum, PostFundTurnNum, PreFundTurnNum } from './constants';
 import { Allocation } from './state/outcome/allocation';
 import { SignedState } from './state/signedstate';
 import { FixedPart, State, ConstructorOptions as FixedPartConstructorOptions } from './state/state';
+import {
+  AllocationUpdatedEvent, ChainEvent, ConcludedEvent, DepositedEvent,
+} from '../node/engine/chainservice/chainservice';
 
 interface ConstructorOptions extends FixedPartConstructorOptions {
   id?: Destination;
@@ -32,6 +35,8 @@ export class Channel extends FixedPart {
 
   onChainFunding: Funds = new Funds();
 
+  latestBlockNumber: Uint64 = BigInt(0); // the latest block number we've seen
+
   // Support []uint64 // TODO: this property will be important, and allow the Channel to store the necessary data to close out the channel on chain
   // It could be an array of turnNums, which can be used to slice into Channel.SignedStateForTurnNum
 
@@ -46,6 +51,7 @@ export class Channel extends FixedPart {
     id: { type: 'class', value: Destination },
     myIndex: { type: 'uint' },
     onChainFunding: { type: 'class', value: Funds },
+    latestBlockNumber: { type: 'uint64' },
     ...super.jsonEncodingMap,
     signedStateForTurnNum: { type: 'map', key: { type: 'uint64' }, value: { type: 'class', value: SignedState } },
     latestSupportedStateTurnNum: { type: 'uint64' },
@@ -326,5 +332,33 @@ export class Channel extends FixedPart {
     }
 
     return ss;
+  }
+
+  // UpdateWithChainEvent mutates the receiver if provided with a "new" chain event (with a greater block number than previously seen)
+  updateWithChainEvent(event: ChainEvent): Channel {
+    if (event.blockNum() < this.latestBlockNumber) {
+      return this; // ignore stale information TODO: is this reorg safe?
+    }
+    this.latestBlockNumber = event.blockNum();
+    switch (true) {
+      case event instanceof AllocationUpdatedEvent: {
+        const e = event as AllocationUpdatedEvent;
+        this.onChainFunding.value.set(e.assetAndAmount.assetAddress, e.assetAndAmount.assetAmount!);
+        break;
+      }
+      case event instanceof DepositedEvent: {
+        const e = event as DepositedEvent;
+        this.onChainFunding.value.set(e.asset, e.nowHeld!);
+        break;
+      }
+      case event instanceof ConcludedEvent: {
+        break;
+      }
+      default: {
+        throw new Error(`channel ${this} cannot handle event ${event}`);
+      }
+    }
+
+    return this;
   }
 }

--- a/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
@@ -383,7 +383,7 @@ export class EthChainService implements ChainService {
             const nad = this.na.interface.parseLog(l).args as unknown as DepositedEventObject;
             const event = DepositedEvent.newDepositedEvent(
               new Destination(nad.destination),
-              String(l.blockNumber),
+              BigInt(l.blockNumber),
               nad.asset,
               nad.destinationHoldings.toBigInt(),
             );
@@ -429,7 +429,7 @@ export class EthChainService implements ChainService {
           assert(assetAddress !== undefined);
           const event = AllocationUpdatedEvent.newAllocationUpdatedEvent(
             new Destination(au.channelId),
-            String(l.blockNumber),
+            BigInt(l.blockNumber),
             assetAddress,
             au.finalHoldings.toBigInt(),
           );
@@ -440,7 +440,7 @@ export class EthChainService implements ChainService {
           this.logger('Processing Concluded event');
           try {
             const ce = this.na.interface.parseLog(l).args as unknown as ConcludedEventObject;
-            const event = new ConcludedEvent({ _channelID: new Destination(ce.channelId), blockNum: String(l.blockNumber) });
+            const event = new ConcludedEvent({ _channelID: new Destination(ce.channelId), _blockNum: BigInt(l.blockNumber) });
             await this.out.push(event);
           } catch (err) {
             throw new Error(`error in ParseConcluded: ${err}`);

--- a/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
@@ -93,8 +93,6 @@ export class P2PMessageService implements MessageService {
   }
 
   // newMessageService returns a running P2PMessageService listening on the given ip, port and message key.
-  // If useMdnsPeerDiscovery is true, the message service will use mDNS to discover peers.
-  // Otherwise, peers must be added manually via `AddPeers`.
   static async newMessageService(
     me: Address,
     peer: Peer,

--- a/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
@@ -135,7 +135,7 @@ export class P2PMessageService implements MessageService {
     return PeerIdFactory.createFromPrivKey(this.key);
   }
 
-  // Method to exchange info with already connected peers
+  // Custom Method to exchange info with already connected peers
   private async exchangeInfoWithConnectedPeers() {
     const peerIds = this.p2pHost.getPeers();
 

--- a/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
@@ -146,6 +146,9 @@ export class P2PMessageService implements MessageService {
     }));
   }
 
+  // handleChangeProtocols is called by the libp2p node when a peer changes protocol.
+  // This is similar to HandlePeerFound method in go-nitro, which has been now removed
+  // https://github.com/statechannels/go-nitro/pull/1534/
   private async handleChangeProtocols({ detail: data }: CustomEvent<PeerProtocolsChangeData>) {
     // Ignore self protocol changes
     if (data.peerId.equals(this.p2pHost.peerId)) {
@@ -161,7 +164,9 @@ export class P2PMessageService implements MessageService {
     await this.exchangePeerInfo(data.peerId);
   }
 
-  // handlePeerProtocols is called by the libp2p node when a peer protocols are updated.
+  // handlePeerConnect is called by the libp2p node when a peer gets connected.
+  // This is similar to HandlePeerFound method in go-nitro, which has been now removed
+  // https://github.com/statechannels/go-nitro/pull/1534/
   private async handlePeerConnect({ detail: data }: CustomEvent<Connection>) {
     assert(this.p2pHost);
 
@@ -176,6 +181,8 @@ export class P2PMessageService implements MessageService {
     await this.exchangePeerInfo(data.remotePeer);
   }
 
+  // Custom method to exchange peer info
+  // Method is called by handleChangeProtocols and handlePeerConnect
   private async exchangePeerInfo(peerId: PeerId) {
     for (let i = 0; i < NUM_CONNECT_ATTEMPTS; i += 1) {
       try {
@@ -257,6 +264,8 @@ export class P2PMessageService implements MessageService {
 
   // sendPeerInfo sends our peer info over the given stream
   // Triggered whenever node establishes a connection with a peer
+  // This is similar to SendPeerInfo method in go-nitro, which has been now removed
+  // https://github.com/statechannels/go-nitro/pull/1534/
   private async sendPeerInfo(recipientId: PeerId): Promise<void> {
     let deferSreamClose;
     let stream: Stream;
@@ -308,6 +317,8 @@ export class P2PMessageService implements MessageService {
   }
 
   // receivePeerInfo receives peer info from the given stream
+  // This is similar to ReceivePeerInfo method in go-nitro, which has been now removed
+  // https://github.com/statechannels/go-nitro/pull/1534/
   private async receivePeerInfo({ stream }: IncomingStreamData) {
     let deferStreamClose;
     try {

--- a/packages/nitro-node/src/protocols/directdefund/directdefund.ts
+++ b/packages/nitro-node/src/protocols/directdefund/directdefund.ts
@@ -278,30 +278,6 @@ export class Objective implements ObjectiveInterface {
     return updated;
   }
 
-  // UpdateWithChainEvent updates the objective with observed on-chain data.
-  //
-  // Only Allocation Updated events are currently handled.
-  updateWithChainEvent(event: ChainEvent): ObjectiveInterface {
-    const updated = this.clone();
-
-    switch (event.constructor) {
-      case AllocationUpdatedEvent: {
-        const e = event as AllocationUpdatedEvent;
-
-        // todo: check block number
-        updated.c!.onChainFunding.value.set(e.assetAndAmount!.assetAddress!, e.assetAndAmount!.assetAmount!);
-        break;
-      }
-      case ConcludedEvent: {
-        break;
-      }
-      default:
-        throw new Error(`objective ${JSONbigNative.stringify(updated)} cannot handle event ${JSONbigNative.stringify(event)}`);
-    }
-
-    return updated;
-  }
-
   // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
   async crank(signer: NitroSigner): Promise<[Objective, SideEffects, WaitingFor]> {
     const updated = this.clone();

--- a/packages/nitro-node/src/utils/test/constants.ts
+++ b/packages/nitro-node/src/utils/test/constants.ts
@@ -1,19 +1,24 @@
 import { Actor } from '../types';
 
 // https://github.com/cerc-io/go-nitro/blob/ts-port-v1.0/scripts/test-configs/alice.toml
+// PeerID: 12D3KooWCKG2HgD24cjCnfmCRRmoeyxFALVrZkTiyBwfZGXQB2Zt
 export const ALICE_ADDRESS = '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE';
 export const ALICE_PK = '2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d';
 
 // https://github.com/cerc-io/go-nitro/blob/ts-port-v1.0/scripts/test-configs/bob.toml
+// PeerID: 12D3KooWDyNacKpCKiTzPxB9vRqr1fga7hw1g9Kt1RZPmxeEuv41
 export const BOB_ADDRESS = '0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94';
 export const BOB_PK = '0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4';
 
+// PeerID: 12D3KooWBF1EBPG8NvquDTXUxHM6ituxXZoLNUcT8j1ErYRSmj7t
 export const CHARLIE_ADDRESS = '0x67D5b55604d1aF90074FcB69b8C51838FFF84f8d';
 export const CHARLIE_PK = '58368d20ff12f17669c06158c21d885897aa56f9be430edc789614bf9851d53f';
 
+// PeerID: 12D3KooWSvACfUBFeFsgrb4Hc8Cj9ezopkNnfeqF371yfnHX5Vdo
 export const DAVID_ADDRESS = '0x111A00868581f73AB42FEEF67D235Ca09ca1E8db';
 export const DAVID_PK = 'febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781';
 
+// PeerID: 12D3KooWCygmPonhiJ5CvDdTsZpRrpdJffkypViANtpgBwzZu5jn
 export const ERIN_ADDRESS = '0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01';
 export const ERIN_PK = '0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5337,6 +5337,13 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+async-mutex@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.4.0.tgz#ae8048cd4d04ace94347507504b3cf15e631c25f"
+  integrity sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==
+  dependencies:
+    tslib "^2.4.0"
+
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.npmjs.org/async/-/async-3.2.4.tgz"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Replace `PeerInfoExchange` with `BasicPeerInfo`
- Implement `updateEventTracker` method to refactor `eventQueue`
- Port over Go mutex implementation
- Allow `Channels` to handle `ChainEvents` without help of Objectives