### PR TITLE
Port latest changes from go-nitro till commit `e922d7e` on August 23

### DIFF
--- a/packages/nitro-node/src/channel/channel.ts
+++ b/packages/nitro-node/src/channel/channel.ts
@@ -37,9 +37,6 @@ export class Channel extends FixedPart {
 
   latestBlockNumber: Uint64 = BigInt(0); // the latest block number we've seen
 
-  // Support []uint64 // TODO: this property will be important, and allow the Channel to store the necessary data to close out the channel on chain
-  // It could be an array of turnNums, which can be used to slice into Channel.SignedStateForTurnNum
-
   signedStateForTurnNum: Map<Uint64, SignedState> = new Map();
   // Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 
@@ -82,7 +79,6 @@ export class Channel extends FixedPart {
     c.onChainFunding = new Funds();
     Object.assign(c, s.fixedPart().clone());
     c.latestSupportedStateTurnNum = MaxTurnNum; // largest uint64 value reserved for "no supported state"
-    // c.Support =  // TODO
 
     // Store prefund
     c.signedStateForTurnNum = new Map();
@@ -295,8 +291,6 @@ export class Channel extends FixedPart {
     if (this.signedStateForTurnNum.get(s.turnNum)!.hasAllSignatures()) {
       this.latestSupportedStateTurnNum = s.turnNum;
     }
-
-    // TODO update support
 
     return true;
   }

--- a/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
@@ -522,7 +522,6 @@ export class EthChainService implements ChainService {
           this.logger(`detected new block: ${newBlockNum}`);
           // eslint-disable-next-line no-await-in-loop
           await this.updateEventTracker(errorChan, newBlockNum, undefined);
-          this.logger(`detected new block: ${newBlockNum}`);
           break;
         }
       }

--- a/packages/nitro-node/src/node/engine/engine.ts
+++ b/packages/nitro-node/src/node/engine/engine.ts
@@ -61,6 +61,7 @@ import { Destination } from '../../types/destination';
 const log = debug('ts-nitro:engine');
 
 const SENT_VOUCHERS_CHANNEL_BUFFER_SIZE = 100;
+const METRICS_ENABLED = false;
 
 class ErrUnhandledChainEvent extends Error {
   event?: ChainEvent;
@@ -225,14 +226,18 @@ export class Engine {
 
     e.logger('Constructed Engine');
 
-    if (!metricsApi) {
-      // eslint-disable-next-line no-param-reassign
-      metricsApi = new NoOpMetrics();
+    if (METRICS_ENABLED) {
+      // If a metrics API is not provided we used the no-op version which does nothing.
+      if (!metricsApi) {
+        // eslint-disable-next-line no-param-reassign
+        metricsApi = new NoOpMetrics();
+      }
+
+      e.metrics = MetricsRecorder.newMetricsRecorder(
+        e.store.getAddress(),
+        metricsApi,
+      );
     }
-    e.metrics = MetricsRecorder.newMetricsRecorder(
-      e.store.getAddress(),
-      metricsApi,
-    );
 
     e.wg = new WaitGroup();
 
@@ -279,11 +284,13 @@ export class Engine {
       let res = new EngineEvent({});
       let err: Error | null = null;
 
-      this.metrics!.recordQueueLength('api_objective_request_queue', this.objectiveRequestsFromAPI.channelLength());
-      this.metrics!.recordQueueLength('api_payment_request_queue', this.paymentRequestsFromAPI.channelLength());
-      this.metrics!.recordQueueLength('chain_events_queue', this.fromChain.channelLength());
-      this.metrics!.recordQueueLength('messages_queue', this.fromMsg.channelLength());
-      this.metrics!.recordQueueLength('proposal_queue', this.fromLedger.channelLength());
+      if (METRICS_ENABLED) {
+        this.metrics!.recordQueueLength('api_objective_request_queue', this.objectiveRequestsFromAPI.channelLength());
+        this.metrics!.recordQueueLength('api_payment_request_queue', this.paymentRequestsFromAPI.channelLength());
+        this.metrics!.recordQueueLength('chain_events_queue', this.fromChain.channelLength());
+        this.metrics!.recordQueueLength('messages_queue', this.fromMsg.channelLength());
+        this.metrics!.recordQueueLength('proposal_queue', this.fromLedger.channelLength());
+      }
 
       /* eslint-disable no-await-in-loop */
       /* eslint-disable default-case */
@@ -331,7 +338,10 @@ export class Engine {
         res.completedObjectives?.forEach((obj) => {
           assert(this.logger);
           this.logger(`Objective ${obj.id()} is complete & returned to API`);
-          this.metrics!.recordObjectiveCompleted(obj.id());
+
+          if (METRICS_ENABLED) {
+            this.metrics!.recordObjectiveCompleted(obj.id());
+          }
         });
 
         this.eventHandler(res);
@@ -345,8 +355,10 @@ export class Engine {
   private async handleProposal(proposal: Proposal): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleProposal.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleProposal.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.store);
       const id = getProposalObjectiveId(proposal);
@@ -380,8 +392,10 @@ export class Engine {
   private async handleMessage(message: Message): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = () => this.metrics!.recordFunctionDuration(this.handleMessage.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = () => this.metrics!.recordFunctionDuration(this.handleMessage.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.policymaker);
       assert(this.store);
@@ -580,8 +594,10 @@ export class Engine {
   private async handleChainEvent(chainEvent: ChainEvent): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleChainEvent.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleChainEvent.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert('string' in chainEvent && typeof chainEvent.string === 'function');
       this.logger(`handling chain event: ${chainEvent.string()}`);
@@ -632,8 +648,10 @@ export class Engine {
     let deferredSignalObjectiveStarted;
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleObjectiveRequest.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.handleObjectiveRequest.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.store);
       assert(this.chain);
@@ -672,7 +690,10 @@ export class Engine {
           } catch (err) {
             return [failedEngineEvent, new Error(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`)];
           }
-          this.metrics!.recordObjectiveStarted(vfo.id());
+
+          if (METRICS_ENABLED) {
+            this.metrics!.recordObjectiveStarted(vfo.id());
+          }
 
           // Only Alice or Bob care about registering the objective and keeping track of vouchers
           const lastParticipant = BigInt((vfo.v!.participants ?? []).length - 1);
@@ -721,7 +742,9 @@ export class Engine {
               this.store.getConsensusChannel.bind(this.store),
             );
 
-            this.metrics!.recordObjectiveStarted(vdfo.id());
+            if (METRICS_ENABLED) {
+              this.metrics!.recordObjectiveStarted(vdfo.id());
+            }
           } catch (err) {
             return [
               failedEngineEvent,
@@ -744,7 +767,9 @@ export class Engine {
               this.store.getConsensusChannel.bind(this.store),
             );
 
-            this.metrics!.recordObjectiveStarted(dfo.id());
+            if (METRICS_ENABLED) {
+              this.metrics!.recordObjectiveStarted(dfo.id());
+            }
           } catch (err) {
             return [
               failedEngineEvent,
@@ -770,7 +795,10 @@ export class Engine {
               new Error(`handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
             ];
           }
-          this.metrics!.recordObjectiveStarted(ddfo.id());
+
+          if (METRICS_ENABLED) {
+            this.metrics!.recordObjectiveStarted(ddfo.id());
+          }
           // If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
           try {
             await this.store.destroyConsensusChannel(request.channelId);
@@ -854,15 +882,20 @@ export class Engine {
   private async sendMessages(msgs: Message[]): Promise<void> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.sendMessages.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.sendMessages.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.store);
       assert(this.msg);
       for await (const message of msgs) {
         message.from = this.store.getAddress();
         this.logMessage(message, Outgoing);
-        this.recordMessageMetrics(message);
+
+        if (METRICS_ENABLED) {
+          this.recordMessageMetrics(message);
+        }
         try {
           await this.msg.send(message);
         } catch (err) {
@@ -881,8 +914,10 @@ export class Engine {
   private async executeSideEffects(sideEffects: SideEffects): Promise<void> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.executeSideEffects.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.executeSideEffects.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       this.wg!.add(1);
       // Send messages in a go routine so that we don't block on message delivery
@@ -916,8 +951,10 @@ export class Engine {
   private async attemptProgress(objective: Objective): Promise<[EngineEvent, Error | null]> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.attemptProgress.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.attemptProgress.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       const outgoing = new EngineEvent({});
 
@@ -1056,8 +1093,10 @@ export class Engine {
   private async spawnConsensusChannelIfDirectFundObjective(crankedObjective: Objective): Promise<void> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.spawnConsensusChannelIfDirectFundObjective.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.spawnConsensusChannelIfDirectFundObjective.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       if (crankedObjective instanceof DirectFundObjective) {
         const dfo = crankedObjective as DirectFundObjective;
@@ -1095,8 +1134,10 @@ export class Engine {
   private async getOrCreateObjective(p: ObjectivePayload): Promise<Objective> {
     let deferredCompleteRecordFunction;
     try {
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.getOrCreateObjective.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.getOrCreateObjective.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.store);
 
@@ -1114,7 +1155,9 @@ export class Engine {
             throw new Error(`error constructing objective from message: ${constructErr}`);
           }
 
-          this.metrics!.recordObjectiveStarted(newObj.id());
+          if (METRICS_ENABLED) {
+            this.metrics!.recordObjectiveStarted(newObj.id());
+          }
 
           try {
             await this.store.setObjective(newObj);
@@ -1141,8 +1184,10 @@ export class Engine {
     let deferredCompleteRecordFunction;
     try {
       this.logger(`Constructing objective ${id} from message`);
-      const completeRecordFunction = this.metrics!.recordFunctionDuration(this.constructObjectiveFromMessage.name);
-      deferredCompleteRecordFunction = () => completeRecordFunction();
+      if (METRICS_ENABLED) {
+        const completeRecordFunction = this.metrics!.recordFunctionDuration(this.constructObjectiveFromMessage.name);
+        deferredCompleteRecordFunction = () => completeRecordFunction();
+      }
 
       assert(this.store);
       assert(this.vm);

--- a/packages/nitro-node/src/node/engine/engine.ts
+++ b/packages/nitro-node/src/node/engine/engine.ts
@@ -971,7 +971,11 @@ export class Engine {
         return [outgoing, err as Error];
       }
 
-      await this.store.setObjective(crankedObjective);
+      try {
+        await this.store.setObjective(crankedObjective);
+      } catch (err) {
+        return [new EngineEvent({}), err as Error];
+      }
 
       let notifEvents: EngineEvent;
       try {

--- a/packages/nitro-node/src/node/node.ts
+++ b/packages/nitro-node/src/node/node.ts
@@ -83,12 +83,6 @@ export class Node {
     const n = new Node();
     n.address = store.getAddress();
 
-    // If a metrics API is not provided we used the no-op version which does nothing.
-    if (!metricsApi) {
-      // eslint-disable-next-line no-param-reassign
-      metricsApi = new NoOpMetrics();
-    }
-
     const chainId = await chainservice.getChainId();
     n.chainId = chainId;
     n.store = store;

--- a/packages/server/test-e2e/integration.test.ts
+++ b/packages/server/test-e2e/integration.test.ts
@@ -44,6 +44,7 @@ const CHARLIE_BALANCE_AFTER_DIRECTDEFUND_WITH_INTERMEDIARY = '1000150';
 const INITIAL_LEDGER_AMOUNT = 1_000_000;
 const INITIAL_VIRTUAL_CHANNEL_AMOUNT = 1_000_000;
 const ASSET = `0x${'00'.repeat(20)}`;
+const METRICS_ENABLED = false;
 
 async function createNode(actor: utils.Actor, contractAddresses: ContractAddresses): Promise<[Node, P2PMessageService, Metrics]> {
   const nodePeerIdObj = await createPeerIdFromKey(hex2Bytes(actor.privateKey));
@@ -240,8 +241,10 @@ describe('test payment flows', () => {
 
       await waitForPeerInfoExchange([aliceMsgService, bobMsgService]);
 
-      expect(aliceMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_NODE_INSTANTIATION, ACTORS.alice.address));
-      expect(bobMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_NODE_INSTANTIATION, ACTORS.bob.address));
+      if (METRICS_ENABLED) {
+        expect(aliceMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_NODE_INSTANTIATION, ACTORS.alice.address));
+        expect(bobMetrics.getMetrics()).to.includes.keys(...getMetricsKey(METRICS_KEYS_NODE_INSTANTIATION, ACTORS.bob.address));
+      }
     });
 
     it('should create a ledger channel', async () => {
@@ -271,27 +274,29 @@ describe('test payment flows', () => {
       aliceChainBalance = await checkAndUpdateChainBalance(ACTORS.alice, DEFAULT_CHAIN_URL, aliceChainBalance);
       bobChainBalance = await checkAndUpdateChainBalance(ACTORS.bob, DEFAULT_CHAIN_URL, bobChainBalance);
 
-      expect(aliceMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.alice.address, ACTORS.bob.address));
-      expect(bobMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.bob.address, ACTORS.alice.address));
+      if (METRICS_ENABLED) {
+        expect(aliceMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.alice.address, ACTORS.bob.address));
+        expect(bobMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_payload_size', ACTORS.bob.address, ACTORS.alice.address));
 
-      expect(aliceMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_size', ACTORS.alice.address, ACTORS.bob.address));
-      expect(bobMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_size', ACTORS.bob.address, ACTORS.alice.address));
+        expect(aliceMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_size', ACTORS.alice.address, ACTORS.bob.address));
+        expect(bobMetrics.getMetrics()).to.have.property(getMetricsMessage('msg_size', ACTORS.bob.address, ACTORS.alice.address));
 
-      expect(aliceMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.alice.address, ACTORS.bob.address));
-      expect(bobMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.bob.address, ACTORS.alice.address));
+        expect(aliceMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.alice.address, ACTORS.bob.address));
+        expect(bobMetrics.getMetrics()).to.include(getMetricsMessageObj(METRICS_MESSAGE_KEYS_VALUES, ACTORS.bob.address, ACTORS.alice.address));
 
-      expect(aliceMetrics.getMetrics()).to.include.keys(...getMetricsKey(METRICS_KEYS_DIRECT_FUND, ACTORS.alice.address));
+        expect(aliceMetrics.getMetrics()).to.include.keys(...getMetricsKey(METRICS_KEYS_DIRECT_FUND, ACTORS.alice.address));
 
-      getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.alice.address).forEach((key) => {
-        expect(aliceMetrics.getMetrics()[key]).to.be.above(0);
-      });
+        getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.alice.address).forEach((key) => {
+          expect(aliceMetrics.getMetrics()[key]).to.be.above(0);
+        });
 
-      getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.bob.address).forEach((key) => {
-        expect(bobMetrics.getMetrics()[key]).to.be.above(0);
-      });
+        getMetricsKey(METRICS_KEYS_FUNCTIONS, ACTORS.bob.address).forEach((key) => {
+          expect(bobMetrics.getMetrics()[key]).to.be.above(0);
+        });
 
-      expect(aliceMetrics.getMetrics()[getMetricsKey(['handleObjectiveRequest'], ACTORS.alice.address)[0]]).to.be.above(0);
-      expect(bobMetrics.getMetrics()[getMetricsKey(['constructObjectiveFromMessage'], ACTORS.bob.address)[0]]).to.be.above(0);
+        expect(aliceMetrics.getMetrics()[getMetricsKey(['handleObjectiveRequest'], ACTORS.alice.address)[0]]).to.be.above(0);
+        expect(bobMetrics.getMetrics()[getMetricsKey(['constructObjectiveFromMessage'], ACTORS.bob.address)[0]]).to.be.above(0);
+      }
     });
 
     it('should create a virtual channel', async () => {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Add flag to record metrics
  - Recording metrics has been removed from go-nitro
  - So `METRICS_ENABLED` flag in ts-nitro has set to false
-  Remove comments about adding support to channel