### PR TITLE
Remove voucher subscription for logs from Nitro setup

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.1.9"
+  "version": "0.1.10"
 }

--- a/packages/example-web-app/package.json
+++ b/packages/example-web-app/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@cerc-io/example-web-app",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "dependencies": {
-    "@cerc-io/nitro-node": "^0.1.9",
+    "@cerc-io/nitro-node": "^0.1.10",
     "@libp2p/crypto": "^1.0.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -11,7 +11,8 @@ import './App.css';
 const {
   ACTORS,
   createPeerIdFromKey,
-  createPeerAndInit
+  createPeerAndInit,
+  subscribeVoucherLogs
 } = utils;
 
 declare global {
@@ -34,7 +35,7 @@ window.setupNode = async (name: string): Promise<utils.Nitro> => {
   const peerIdObj = await createPeerIdFromKey(hex2Bytes(actor.privateKey));
   const peer = await createPeerAndInit(process.env.REACT_APP_RELAY_MULTIADDR, {}, peerIdObj);
 
-  return utils.Nitro.setupNode(
+  const nitro = await utils.Nitro.setupNode(
     actor.privateKey,
     DEFAULT_CHAIN_URL,
     actor.chainPrivateKey,
@@ -44,6 +45,11 @@ window.setupNode = async (name: string): Promise<utils.Nitro> => {
     undefined,
     process.env.REACT_APP_ASSET_ADDRESS
   );
+
+  // Subscribe to vouchers and log them
+  subscribeVoucherLogs(nitro.node);
+
+  return nitro;
 };
 
 window.out = (jsonObject) => {

--- a/packages/nitro-node/package.json
+++ b/packages/nitro-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/nitro-node",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
@@ -50,7 +50,7 @@
   "dependencies": {
     "@cerc-io/libp2p": "0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.2",
-    "@cerc-io/nitro-util": "^0.1.9",
+    "@cerc-io/nitro-util": "^0.1.10",
     "@cerc-io/peer": "^0.2.56",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@jpwilliams/waitgroup": "^2.1.0",

--- a/packages/nitro-node/src/node/node.ts
+++ b/packages/nitro-node/src/node/node.ts
@@ -273,7 +273,8 @@ export class Node {
 
   // ReceivedVouchers returns a chan that receives a voucher every time we receive a payment voucher
   receivedVouchers(): ReadChannel<Voucher> {
-    return this._receivedVouchers!;
+    // TODO: Register listeners and send voucher to each instead
+    return this._receivedVouchers!.readOnly();
   }
 
   // CreateVoucher creates and returns a voucher for the given channelId which increments the redeemable balance by amount.

--- a/packages/nitro-node/src/utils/nitro.ts
+++ b/packages/nitro-node/src/utils/nitro.ts
@@ -83,7 +83,6 @@ export class Nitro {
       metricsApi,
     );
 
-    subscribeVoucherLogs(node);
     return new Nitro(node, msgService, chainService, keySigner, store);
   }
 
@@ -114,7 +113,6 @@ export class Nitro {
       metricsApi,
     );
 
-    subscribeVoucherLogs(node);
     return new Nitro(node, msgService, chainService, snapSigner, store);
   }
 

--- a/packages/nitro-util/package.json
+++ b/packages/nitro-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/nitro-util",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/server",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "index.js",
   "license": "MIT",
   "private": true,
@@ -33,8 +33,8 @@
     "chain:anvil": "hardhat --config hardhat.anvil.config.ts node"
   },
   "dependencies": {
-    "@cerc-io/nitro-node": "^0.1.9",
-    "@cerc-io/nitro-util": "^0.1.9",
+    "@cerc-io/nitro-node": "^0.1.10",
+    "@cerc-io/nitro-util": "^0.1.10",
     "assert": "^2.0.0",
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ const log = debug('ts-nitro:server');
 const {
   createPeerIdFromKey,
   createPeerAndInit,
+  subscribeVoucherLogs,
 } = utils;
 
 const getArgv = () => yargs.parserConfiguration({
@@ -145,7 +146,8 @@ const main = async () => {
     asset,
   );
 
-  log('Started P2PMessageService');
+  subscribeVoucherLogs(nitro.node);
+  log('Started P2PMessageService and subscribed to vouchers');
 
   const peersToConnect: string[] = argv.counterparty ? [argv.counterparty] : [];
   peersToConnect.push(...(argv.intermediaries as string[]));


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/411

- Remove voucher subscription from Nitro setup so that they can be listened to elsewhere
  - Requires corresponding downstream changes where `setupNode()` or `setupNodeWithProvider()` is called