### PR TITLE
Always update peers map on receiving peer info

### DIFF
--- a/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
+++ b/packages/nitro-node/src/node/engine/messageservice/p2p-message-service/service.ts
@@ -373,18 +373,16 @@ export class P2PMessageService implements MessageService {
         return;
       }
 
-      const [, foundPeer] = this.peers!.loadOrStore(msg!.address.toString(), msg!.id);
-      if (!foundPeer) {
-        const peerInfo: BasicPeerInfo = {
-          id: msg!.id,
-          address: msg!.address,
-        };
+      this.peers!.store(msg.address.toString(), msg.id);
 
-        this.logger(`stored new peer in map: ${JSON.stringify(peerInfo)}`);
+      const peerInfo: BasicPeerInfo = {
+        id: msg!.id,
+        address: msg!.address,
+      };
+      this.logger(`stored new peer in map: ${JSON.stringify(peerInfo)}`);
 
-        // Use a non-blocking send in case no one is listening
-        this.newPeerInfo!.push(peerInfo);
-      }
+      // Use a non-blocking send in case no one is listening
+      this.newPeerInfo!.push(peerInfo);
     } finally {
       if (deferStreamClose) {
         deferStreamClose();
@@ -422,6 +420,7 @@ export class P2PMessageService implements MessageService {
 
         return;
       } catch (err) {
+        // TODO: Fix error logging, JSON.stringify results into err field being {} for Error class
         this.logger(JSON.stringify({
           msg: 'error opening stream',
           err,

--- a/packages/nitro-util/scripts/balance.ts
+++ b/packages/nitro-util/scripts/balance.ts
@@ -48,16 +48,16 @@ async function main() {
   if (argv.address) {
     address = argv.address;
   } else if (argv.key) {
-    address = await getAddressByKey(argv.key, DEFAULT_CHAIN_URL);
+    address = await getAddressByKey(argv.key, argv.chainurl);
   } else {
     throw new Error('Provide either address or private key of an account');
   }
 
   if (argv.token) {
-    const balance = await getTokenBalanceByAddress(argv.token, address, DEFAULT_CHAIN_URL);
+    const balance = await getTokenBalanceByAddress(argv.token, address, argv.chainurl);
     log(`Token balance of account ${address} is ${balance.toString()}`);
   } else {
-    const balance = await getBalanceByAddress(address, DEFAULT_CHAIN_URL);
+    const balance = await getBalanceByAddress(address, argv.chainurl);
     log(`ETH balance of account ${address} is ${balance.toString()}`);
   }
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Always update in-memory peers map on receiving peer info even if an entry for a Nitro account exists as it's peer id may change