### PR TITLE
Use WebSocket provider in ETH chain service and upgrade nitro-protocol

### DIFF
--- a/packages/example-web-app/src/App.tsx
+++ b/packages/example-web-app/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import assert from 'assert';
 
 import { utils } from '@cerc-io/nitro-node';
-import { JSONbigNative, hex2Bytes, DEFAULT_CHAIN_URL } from '@cerc-io/nitro-util';
+import { JSONbigNative, hex2Bytes, DEFAULT_CHAIN_URL_WEBSOCKET } from '@cerc-io/nitro-util';
 
 import contractAddresses from './nitro-addresses.json';
 import logo from './logo.svg';
@@ -37,7 +37,7 @@ window.setupNode = async (name: string): Promise<utils.Nitro> => {
 
   const nitro = await utils.Nitro.setupNode(
     actor.privateKey,
-    DEFAULT_CHAIN_URL,
+    DEFAULT_CHAIN_URL_WEBSOCKET,
     actor.chainPrivateKey,
     contractAddresses,
     peer,

--- a/packages/nitro-node/package.json
+++ b/packages/nitro-node/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@cerc-io/libp2p": "0.42.2-laconic-0.1.4",
-    "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.2",
+    "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.3",
     "@cerc-io/nitro-util": "^0.1.11",
     "@cerc-io/peer": "^0.2.58",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",

--- a/packages/nitro-node/src/channel/channel.ts
+++ b/packages/nitro-node/src/channel/channel.ts
@@ -412,7 +412,7 @@ export class Channel extends FixedPart {
         const e = event as ChallengeRegisteredEvent;
 
         const h = e.stateHash(this);
-        this.onChain.stateHash = ethers.utils.hexZeroPad(h, 32);
+        this.onChain.stateHash = h;
         this.onChain.outcome = e.outcome();
 
         const ss = e.SignedState(this);

--- a/packages/nitro-node/src/channel/channel.ts
+++ b/packages/nitro-node/src/channel/channel.ts
@@ -1,10 +1,12 @@
 import assert from 'assert';
 import _ from 'lodash';
 import { Buffer } from 'buffer';
+import { ethers } from 'ethers';
 
 import {
   fromJSON, toJSON, FieldDescription, Uint, Uint64, NitroSigner,
 } from '@cerc-io/nitro-util';
+import { Bytes32 } from '@cerc-io/nitro-protocol';
 
 import { Signature } from '../crypto/signatures';
 import { Destination } from '../types/destination';
@@ -29,7 +31,7 @@ interface ConstructorOptions extends FixedPartConstructorOptions {
 interface OnChainDataConstructorOptions {
   holdings?: Funds;
   outcome?: Exit;
-  stateHash?: string
+  stateHash?: Bytes32
 }
 
 interface OffChainDataConstructorOptions {
@@ -42,7 +44,7 @@ class OnChainData {
 
   outcome: Exit = new Exit();
 
-  stateHash: string = '';
+  stateHash: Bytes32 = ethers.utils.hexZeroPad([], 32);
 
   constructor(params: OnChainDataConstructorOptions) {
     Object.assign(this, params);
@@ -50,7 +52,7 @@ class OnChainData {
 
   static jsonEncodingMap: Record<string, FieldDescription> = {
     holdings: { type: 'class', value: Funds },
-    myIndex: { type: 'class', value: Exit },
+    outcome: { type: 'class', value: Exit },
     stateHash: { type: 'string' },
   };
 
@@ -410,7 +412,7 @@ export class Channel extends FixedPart {
         const e = event as ChallengeRegisteredEvent;
 
         const h = e.stateHash(this);
-        this.onChain.stateHash = h;
+        this.onChain.stateHash = ethers.utils.hexZeroPad(h, 32);
         this.onChain.outcome = e.outcome();
 
         const ss = e.SignedState(this);

--- a/packages/nitro-node/src/channel/state/state.ts
+++ b/packages/nitro-node/src/channel/state/state.ts
@@ -7,6 +7,7 @@ import {
   getChannelId as utilGetChannelId,
   State as NitroState,
   hashState as utilHashState,
+  Bytes32,
 } from '@cerc-io/nitro-protocol';
 import {
   FieldDescription, NitroSigner, Uint64, bytes2Hex, fromJSON, hex2Bytes, toJSON,
@@ -191,7 +192,7 @@ export class State {
   }
 
   // Hash returns the keccak256 hash of the State
-  hash(): string {
+  hash(): Bytes32 {
     // Use hashState method from @statechannels/nitro-protocol
     // Create NitroState instance from State
     const state: NitroState = this._getNitroState();

--- a/packages/nitro-node/src/node/engine/chainservice/chainservice.ts
+++ b/packages/nitro-node/src/node/engine/chainservice/chainservice.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import type { ReadChannel } from '@cerc-io/ts-channel';
 
 import { Uint64 } from '@cerc-io/nitro-util';
+import { Bytes32 } from '@cerc-io/nitro-protocol';
 
 import { ChainTransaction, Objective } from '../../../protocols/interfaces';
 import { Address } from '../../../types/types';
@@ -156,7 +157,7 @@ export class ChallengeRegisteredEvent extends CommonEvent {
   }
 
   // StateHash returns the statehash stored on chain at the time of the ChallengeRegistered Event firing.
-  stateHash(fp: FixedPart): string {
+  stateHash(fp: FixedPart): Bytes32 {
     return stateFromFixedAndVariablePart(fp, this.canditate!).hash();
   }
 

--- a/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
+++ b/packages/nitro-node/src/node/engine/chainservice/eth-chainservice.ts
@@ -707,6 +707,9 @@ export class EthChainService implements ChainService {
 
   async close(): Promise<void> {
     this.cancel();
+    if (this.chain.provider instanceof providers.WebSocketProvider) {
+      await this.chain.provider.destroy();
+    }
     await this.wg!.wait();
   }
 }

--- a/packages/nitro-util/package.json
+++ b/packages/nitro-util/package.json
@@ -36,7 +36,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.2",
+    "@cerc-io/nitro-protocol": "^2.0.0-alpha.4-ts-port-0.1.3",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "assert": "^2.0.0",
     "debug": "^4.3.4",

--- a/packages/nitro-util/scripts/deploy-contracts.ts
+++ b/packages/nitro-util/scripts/deploy-contracts.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs';
 import fs from 'fs';
 import path from 'path';
 import debug from 'debug';
-import { providers } from 'ethers';
+import { ethers, providers } from 'ethers';
 
 import { DEFAULT_CHAIN_URL } from '../src/constants';
 import { deployContracts } from '../src/deploy-contracts';
@@ -24,17 +24,24 @@ const getArgv = () => yargs.parserConfiguration({
     describe: 'JSON file path to export addresses to',
     default: './nitro-addresses.json',
   },
+  key: {
+    alias: 'k',
+    type: 'string',
+    describe: 'Private key of deployer account',
+  },
 }).argv;
 
 async function main() {
   const argv = getArgv();
 
   const provider = new providers.JsonRpcProvider(argv.chainurl);
+  const signer = argv.key ? new ethers.Wallet(argv.key, provider) : provider.getSigner();
+
   const [
     nitroAdjudicatorAddress,
     virtualPaymentAppAddress,
     consensusAppAddress,
-  ] = await deployContracts(provider.getSigner());
+  ] = await deployContracts(signer);
 
   const output = {
     nitroAdjudicatorAddress,

--- a/packages/nitro-util/scripts/deploy-token.ts
+++ b/packages/nitro-util/scripts/deploy-token.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
 import debug from 'debug';
-import { providers } from 'ethers';
+import { ethers, providers } from 'ethers';
 
 import { DEFAULT_CHAIN_URL } from '../src';
 import { deployToken } from '../src/deploy-contracts';
@@ -17,13 +17,20 @@ const getArgv = () => yargs.parserConfiguration({
     describe: 'RPC endpoint for the chain',
     default: DEFAULT_CHAIN_URL,
   },
+  key: {
+    alias: 'k',
+    type: 'string',
+    describe: 'Private key of deployer account',
+  },
 }).argv;
 
 async function main() {
   const argv = getArgv();
 
   const provider = new providers.JsonRpcProvider(argv.chainurl);
-  const tokenAddress = await deployToken(provider.getSigner(), tokenArtifact);
+  const signer = argv.key ? new ethers.Wallet(argv.key, provider) : provider.getSigner();
+
+  const tokenAddress = await deployToken(signer, tokenArtifact);
 
   log('Token deployed to:', tokenAddress);
 }

--- a/packages/nitro-util/src/constants.ts
+++ b/packages/nitro-util/src/constants.ts
@@ -1,6 +1,7 @@
 // RPC endpoint for the chain
 // Chain should be running locally
-export const DEFAULT_CHAIN_URL = 'ws://127.0.0.1:8545';
+export const DEFAULT_CHAIN_URL = 'http://127.0.0.1:8545';
+export const DEFAULT_CHAIN_URL_WEBSOCKET = 'ws://127.0.0.1:8545';
 
 // Zero address (ETH)
 export const DEFAULT_ASSET = `0x${'00'.repeat(20)}`;

--- a/packages/nitro-util/src/constants.ts
+++ b/packages/nitro-util/src/constants.ts
@@ -1,6 +1,6 @@
 // RPC endpoint for the chain
 // Chain should be running locally
-export const DEFAULT_CHAIN_URL = 'http://127.0.0.1:8545';
+export const DEFAULT_CHAIN_URL = 'ws://127.0.0.1:8545';
 
 // Zero address (ETH)
 export const DEFAULT_ASSET = `0x${'00'.repeat(20)}`;

--- a/packages/nitro-util/src/deploy-contracts.ts
+++ b/packages/nitro-util/src/deploy-contracts.ts
@@ -1,10 +1,10 @@
-import { ContractFactory, providers } from 'ethers';
+import { ContractFactory, Signer } from 'ethers';
 
 import nitroAdjudicatorArtifact from '@cerc-io/nitro-protocol/dist/artifacts/contracts/NitroAdjudicator.sol/NitroAdjudicator.json';
 import consensusAppArtifact from '@cerc-io/nitro-protocol/dist/artifacts/contracts/ConsensusApp.sol/ConsensusApp.json';
 import virtualPaymentAppArtifact from '@cerc-io/nitro-protocol/dist/artifacts/contracts/VirtualPaymentApp.sol/VirtualPaymentApp.json';
 
-export async function deployContracts(signer: providers.JsonRpcSigner): Promise<[string, string, string]> {
+export async function deployContracts(signer: Signer): Promise<[string, string, string]> {
   const nitroAdjudicatorFactory = new ContractFactory(
     nitroAdjudicatorArtifact.abi,
     nitroAdjudicatorArtifact.bytecode,
@@ -29,7 +29,7 @@ export async function deployContracts(signer: providers.JsonRpcSigner): Promise<
   return [nitroAdjudicator.address, virtualPaymentApp.address, consensusApp.address];
 }
 
-export async function deployToken(signer: providers.JsonRpcSigner, artifact: any): Promise<string> {
+export async function deployToken(signer: Signer, artifact: any): Promise<string> {
   const tokenFactory = new ContractFactory(
     artifact.abi,
     artifact.bytecode,

--- a/packages/nitro-util/src/eth-client.ts
+++ b/packages/nitro-util/src/eth-client.ts
@@ -12,7 +12,7 @@ export class EthClient {
 
   static dial(chainUrl: string): EthClient {
     // Connect to the Ethereum provider
-    const provider = new ethers.providers.JsonRpcProvider(chainUrl);
+    const provider = new ethers.providers.WebSocketProvider(chainUrl);
     return new EthClient(provider);
   }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,6 @@
     "cli": "DEBUG=ts-nitro:* ts-node src/index.ts",
     "lint": "eslint .",
     "test:e2e": "mocha test-e2e/**/*.test.ts --bail",
-    "test:deploy-contracts": "DEBUG=ts-nitro:* yarn ts-node test-e2e/scripts/deploy-contracts.ts",
     "chain": "hardhat node",
     "chain:anvil": "hardhat --config hardhat.anvil.config.ts node"
   },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,7 +7,7 @@ import 'dotenv/config';
 
 import { utils } from '@cerc-io/nitro-node';
 import {
-  JSONbigNative, hex2Bytes, DEFAULT_CHAIN_URL, DEFAULT_ASSET,
+  JSONbigNative, hex2Bytes, DEFAULT_CHAIN_URL_WEBSOCKET, DEFAULT_ASSET,
 } from '@cerc-io/nitro-util';
 
 import { waitForMultiplePeers } from './utils/index';
@@ -40,7 +40,7 @@ const getArgv = () => yargs.parserConfiguration({
     alias: 'c',
     type: 'string',
     describe: 'RPC endpoint for the chain',
-    default: DEFAULT_CHAIN_URL,
+    default: DEFAULT_CHAIN_URL_WEBSOCKET,
   },
   contracts: {
     type: 'string',

--- a/packages/server/test-e2e/integration.test.ts
+++ b/packages/server/test-e2e/integration.test.ts
@@ -8,7 +8,7 @@ import {
   ChannelStatus, LedgerChannelBalance, PaymentChannelInfo, PaymentChannelBalance, ObjectiveResponse,
 } from '@cerc-io/nitro-node';
 import {
-  hex2Bytes, DEFAULT_CHAIN_URL, getBalanceByKey, getBalanceByAddress, deployContracts,
+  hex2Bytes, DEFAULT_CHAIN_URL, DEFAULT_CHAIN_URL_WEBSOCKET, getBalanceByKey, getBalanceByAddress, deployContracts,
 } from '@cerc-io/nitro-util';
 
 import {
@@ -53,7 +53,7 @@ async function createNode(actor: utils.Actor, contractAddresses: ContractAddress
 
   const nitro = await utils.Nitro.setupNode(
     actor.privateKey,
-    DEFAULT_CHAIN_URL,
+    DEFAULT_CHAIN_URL_WEBSOCKET,
     actor.chainPrivateKey,
     contractAddresses,
     nodePeer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,10 +1188,10 @@
     wherearewe "^2.0.0"
     xsalsa20 "^1.1.0"
 
-"@cerc-io/nitro-protocol@^2.0.0-alpha.4-ts-port-0.1.2":
-  version "2.0.0-alpha.4-ts-port-0.1.2"
-  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-protocol/-/2.0.0-alpha.4-ts-port-0.1.2/nitro-protocol-2.0.0-alpha.4-ts-port-0.1.2.tgz#6d2f893f5aa08dd5550447f04967b908f3f6d469"
-  integrity sha512-Cyx2+S/6BlAzvl+LZxwLjK2Y0H01f/kvTYUktdsGHx1eTWXTzS6FQ0nTVwJkKEcO8V/Y50+dc2PwvFXvk8iG9w==
+"@cerc-io/nitro-protocol@^2.0.0-alpha.4-ts-port-0.1.3":
+  version "2.0.0-alpha.4-ts-port-0.1.3"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-protocol/-/2.0.0-alpha.4-ts-port-0.1.3/nitro-protocol-2.0.0-alpha.4-ts-port-0.1.3.tgz#586c56ba696857f5cb13cf988277933b1e163dab"
+  integrity sha512-jDZLpw2fvLGqFMNodLkykn/qTEdEyNhxRloKVgdWU973CScV85Q/j5QDsDA87aF4iDOqrgGJkgIs36+MDcXngA==
   dependencies:
     "@openzeppelin/contracts" "^4.7.3"
     "@statechannels/exit-format" "^0.2.0"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Use `WebSocketProvider` in the ETH chain service for subscriptions to have same behaviour as in `go-nitro`
- Fix `OnChainData` type to handle mismatch in `Channel` store object
- Upgrade `@cerc-io/nitro-protocol` for contract changes